### PR TITLE
Quad transform support

### DIFF
--- a/src/main/java/grondag/jmx/api/QuadTransformRegistry.java
+++ b/src/main/java/grondag/jmx/api/QuadTransformRegistry.java
@@ -1,0 +1,28 @@
+package grondag.jmx.api;
+
+import grondag.jmx.impl.QuadTransformRegistryImpl;
+import net.fabricmc.fabric.api.renderer.v1.render.RenderContext;
+import net.minecraft.block.BlockState;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.BlockRenderView;
+
+import javax.annotation.Nullable;
+import java.util.Random;
+import java.util.function.Supplier;
+
+public interface QuadTransformRegistry {
+    interface QuadTransformSource {
+        @Nullable
+        RenderContext.QuadTransform getForBlock(BlockRenderView blockView, BlockState state, BlockPos pos, Supplier<Random> randomSupplier);
+        @Nullable
+        RenderContext.QuadTransform getForItem(ItemStack stack, Supplier<Random> randomSupplier);
+    }
+
+    QuadTransformRegistry INSTANCE = new QuadTransformRegistryImpl();
+
+    void register(Identifier id, QuadTransformSource quadTransformSource);
+
+    @Nullable QuadTransformSource getQuadTransform(Identifier id);
+}

--- a/src/main/java/grondag/jmx/impl/QuadTransformRegistryImpl.java
+++ b/src/main/java/grondag/jmx/impl/QuadTransformRegistryImpl.java
@@ -1,0 +1,26 @@
+package grondag.jmx.impl;
+
+import grondag.jmx.api.QuadTransformRegistry;
+import net.minecraft.util.Identifier;
+
+import javax.annotation.Nullable;
+import java.util.HashMap;
+
+public class QuadTransformRegistryImpl implements QuadTransformRegistry {
+    private final HashMap<Identifier, QuadTransformSource> registeredQuadTransforms = new HashMap<>();
+
+    @Override
+    public void register(Identifier id, QuadTransformSource quadTransformSource) {
+        if (registeredQuadTransforms.containsKey(id)) {
+            throw new IllegalStateException("There is already a quad transform registered with the ID " + id);
+        }
+
+        registeredQuadTransforms.put(id, quadTransformSource);
+    }
+
+    @Nullable
+    @Override
+    public QuadTransformSource getQuadTransform(Identifier id) {
+        return registeredQuadTransforms.get(id);
+    }
+}

--- a/src/main/java/grondag/jmx/impl/QuadTransformRegistryImpl.java
+++ b/src/main/java/grondag/jmx/impl/QuadTransformRegistryImpl.java
@@ -11,6 +11,10 @@ public class QuadTransformRegistryImpl implements QuadTransformRegistry {
 
     @Override
     public void register(Identifier id, QuadTransformSource quadTransformSource) {
+        if (id == null ){
+            throw new IllegalStateException("Cannot register a quad transform with null ID.");
+        }
+
         if (registeredQuadTransforms.containsKey(id)) {
             throw new IllegalStateException("There is already a quad transform registered with the ID " + id);
         }

--- a/src/main/java/grondag/jmx/json/ext/JmxModelExt.java
+++ b/src/main/java/grondag/jmx/json/ext/JmxModelExt.java
@@ -26,6 +26,10 @@ import com.google.gson.JsonObject;
 import grondag.jmx.JsonModelExtensions;
 import grondag.jmx.target.FrexHolder;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.JsonHelper;
+
+import javax.annotation.Nullable;
 
 public class JmxModelExt {
 	public static final ThreadLocal<JmxModelExt> TRANSFER  = new ThreadLocal<>();
@@ -35,14 +39,22 @@ public class JmxModelExt {
 	public JmxModelExt parent;
 
 	private final Map<String, Object> materialMap;
+	@Nullable
+	private final Identifier quadTransformId;
 
 
-	private JmxModelExt(Map<String, Object> materialMap) {
+	private JmxModelExt(Map<String, Object> materialMap, @Nullable Identifier quadTransformId) {
 		this.materialMap = materialMap;
+		this.quadTransformId = quadTransformId;
 	}
 
 	public boolean isEmpty() {
-		return materialMap.isEmpty();
+		return materialMap.isEmpty() && this.getQuadTransformId() == null;
+	}
+
+	@Nullable
+	public Identifier getQuadTransformId() {
+		return this.quadTransformId == null && this.parent != null ? this.parent.getQuadTransformId() : this.quadTransformId;
 	}
 
 	public JmxMaterial resolveMaterial(String matName) {
@@ -95,7 +107,7 @@ public class JmxModelExt {
 		} else if(jsonObjIn.has("jmx")) {
 			deserializeInner(jsonObjIn.getAsJsonObject("jmx"));
 		} else {
-			TRANSFER.set(new JmxModelExt(Collections.emptyMap()));
+			TRANSFER.set(new JmxModelExt(Collections.emptyMap(), null));
 		}
 	}
 
@@ -118,6 +130,15 @@ public class JmxModelExt {
 				map.put(e.getKey(), e.getValue().getAsString());
 			}
 		}
-		TRANSFER.set(new JmxModelExt(map));
+
+		final String idString = JsonHelper.getString(jsonObj, "quad_transform", null);
+		final Identifier quadTransformId;
+		if (idString != null) {
+			quadTransformId = Identifier.tryParse(idString);
+		} else {
+			quadTransformId = null;
+		}
+
+		TRANSFER.set(new JmxModelExt(map, quadTransformId));
 	}
 }

--- a/src/main/java/grondag/jmx/json/model/JmxBakedModel.java
+++ b/src/main/java/grondag/jmx/json/model/JmxBakedModel.java
@@ -260,7 +260,7 @@ public class JmxBakedModel implements BakedModel, FabricBakedModel, Transformabl
 			}
 
 			QuadTransformRegistry.QuadTransformSource quadTransformSource = QuadTransformRegistry.INSTANCE.getQuadTransform(quadTransformId);
-			if (quadTransformSource == null) {
+			if (quadTransformId != null && quadTransformSource == null) {
 				throw new IllegalStateException("No quad transform is registered with ID " + quadTransformId);
 			}
 

--- a/src/main/java/grondag/jmx/json/model/JmxBakedModel.java
+++ b/src/main/java/grondag/jmx/json/model/JmxBakedModel.java
@@ -184,7 +184,8 @@ public class JmxBakedModel implements BakedModel, FabricBakedModel, Transformabl
 			if (this.quadTransformSource != null) {
 				quadTransform = this.quadTransformSource.getForBlock(blockView, state, pos, randomSupplier);
 			} else {
-				quadTransform = null;
+				context.meshConsumer().accept(mesh);
+				return;
 			}
 
 			if (quadTransform != null) {
@@ -204,7 +205,8 @@ public class JmxBakedModel implements BakedModel, FabricBakedModel, Transformabl
 			if (this.quadTransformSource != null) {
 				quadTransform = this.quadTransformSource.getForItem(stack, randomSupplier);
 			} else {
-				quadTransform = null;
+				context.meshConsumer().accept(mesh);
+				return;
 			}
 
 			if (quadTransform != null) {

--- a/src/main/java/grondag/jmx/json/model/JmxBakedModel.java
+++ b/src/main/java/grondag/jmx/json/model/JmxBakedModel.java
@@ -256,17 +256,13 @@ public class JmxBakedModel implements BakedModel, FabricBakedModel, Transformabl
 			if (particleTexture == null) {
 				throw new RuntimeException("Missing particle!");
 			}
-			QuadTransformRegistry.QuadTransformSource quadTransformSupplier;
-			if (quadTransformId != null) {
-				quadTransformSupplier = QuadTransformRegistry.INSTANCE.getQuadTransform(quadTransformId);
-				if (quadTransformSupplier == null) {
-					throw new IllegalStateException("No quad transform is registered with ID " + quadTransformId);
-				}
-			} else {
-				quadTransformSupplier = null;
+
+			QuadTransformRegistry.QuadTransformSource quadTransformSource = QuadTransformRegistry.INSTANCE.getQuadTransform(quadTransformId);
+			if (quadTransformSource == null) {
+				throw new IllegalStateException("No quad transform is registered with ID " + quadTransformId);
 			}
 
-			return new JmxBakedModel(meshBuilder.build(), usesAo, isSideLit, particleTexture, transformation, itemPropertyOverrides, hasDepth, quadTransformSupplier);
+			return new JmxBakedModel(meshBuilder.build(), usesAo, isSideLit, particleTexture, transformation, itemPropertyOverrides, hasDepth, quadTransformSource);
 		}
 
 		private static final BakedQuadFactory QUADFACTORY = new BakedQuadFactory();

--- a/src/main/java/grondag/jmx/json/model/JmxBakedModel.java
+++ b/src/main/java/grondag/jmx/json/model/JmxBakedModel.java
@@ -23,6 +23,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import com.google.common.collect.ImmutableList;
+import grondag.jmx.api.QuadTransformRegistry;
 import org.apache.commons.lang3.ObjectUtils;
 
 import net.minecraft.block.BlockState;
@@ -85,8 +86,9 @@ public class JmxBakedModel implements BakedModel, FabricBakedModel, Transformabl
 	protected final ModelTransformation transformation;
 	protected final ModelOverrideList itemPropertyOverrides;
 	protected final boolean hasDepth;
+	protected final QuadTransformRegistry.QuadTransformSource quadTransformSource;
 
-	public JmxBakedModel(Mesh mesh, boolean usesAo, boolean isSideLit, Sprite particleSprite, ModelTransformation transformation, ModelOverrideList itemPropertyOverrides, boolean hasDepth) {
+	public JmxBakedModel(Mesh mesh, boolean usesAo, boolean isSideLit, Sprite particleSprite, ModelTransformation transformation, ModelOverrideList itemPropertyOverrides, boolean hasDepth, QuadTransformRegistry.QuadTransformSource quadTransformSource) {
 		this.mesh = mesh;
 		this.usesAo = usesAo;
 		this.isSideLit = isSideLit;
@@ -94,6 +96,7 @@ public class JmxBakedModel implements BakedModel, FabricBakedModel, Transformabl
 		this.transformation = transformation;
 		this.itemPropertyOverrides = itemPropertyOverrides;
 		this.hasDepth = hasDepth;
+		this.quadTransformSource = quadTransformSource;
 	}
 
 	@Override
@@ -112,8 +115,10 @@ public class JmxBakedModel implements BakedModel, FabricBakedModel, Transformabl
 			}
 		});
 
-		return new JmxBakedModel(meshBuilder.build(), usesAo, isSideLit, newParticleSprite, transformation,
-				transformItemProperties(context, atlas, meshBuilder), hasDepth);
+		return new JmxBakedModel(
+			meshBuilder.build(), usesAo, isSideLit, newParticleSprite, transformation,
+			transformItemProperties(context, atlas, meshBuilder), hasDepth, quadTransformSource
+		);
 	}
 
 	private ModelOverrideList transformItemProperties(TransformableModelContext context, SpriteAtlasTexture atlas, MeshBuilder meshBuilder) {
@@ -175,14 +180,40 @@ public class JmxBakedModel implements BakedModel, FabricBakedModel, Transformabl
 	@Override
 	public void emitBlockQuads(BlockRenderView blockView, BlockState state, BlockPos pos, Supplier<Random> randomSupplier, RenderContext context) {
 		if(mesh != null) {
-			context.meshConsumer().accept(mesh);
+			QuadTransform quadTransform;
+			if (this.quadTransformSource != null) {
+				quadTransform = this.quadTransformSource.getForBlock(blockView, state, pos, randomSupplier);
+			} else {
+				quadTransform = null;
+			}
+
+			if (quadTransform != null) {
+				context.pushTransform(quadTransform);
+				context.meshConsumer().accept(mesh);
+				context.popTransform();
+			} else {
+				context.meshConsumer().accept(mesh);
+			}
 		}
 	}
 
 	@Override
 	public void emitItemQuads(ItemStack stack, Supplier<Random> randomSupplier, RenderContext context) {
 		if(mesh != null) {
-			context.meshConsumer().accept(mesh);
+			QuadTransform quadTransform;
+			if (this.quadTransformSource != null) {
+				quadTransform = this.quadTransformSource.getForItem(stack, randomSupplier);
+			} else {
+				quadTransform = null;
+			}
+
+			if (quadTransform != null) {
+				context.pushTransform(quadTransform);
+				context.meshConsumer().accept(mesh);
+				context.popTransform();
+			} else {
+				context.meshConsumer().accept(mesh);
+			}
 		}
 	}
 
@@ -197,12 +228,14 @@ public class JmxBakedModel implements BakedModel, FabricBakedModel, Transformabl
 		private final boolean isSideLit;
 		private final ModelTransformation transformation;
 		private final boolean hasDepth;
+		@Nullable
+		private final Identifier quadTransformId;
 
-		public Builder(JsonUnbakedModel unbakedModel, ModelOverrideList itemPropertyOverrides, boolean hasDepth) {
-			this(unbakedModel.useAmbientOcclusion(), unbakedModel.getGuiLight().isSide(), unbakedModel.getTransformations(), itemPropertyOverrides, hasDepth);
+		public Builder(JsonUnbakedModel unbakedModel, ModelOverrideList itemPropertyOverrides, boolean hasDepth, @Nullable Identifier quadTransformId) {
+			this(unbakedModel.useAmbientOcclusion(), unbakedModel.getGuiLight().isSide(), unbakedModel.getTransformations(), itemPropertyOverrides, hasDepth, quadTransformId);
 		}
 
-		private Builder(boolean usesAo, boolean isSideLit, ModelTransformation transformation, ModelOverrideList itemPropertyOverrides, boolean hasDepth) {
+		private Builder(boolean usesAo, boolean isSideLit, ModelTransformation transformation, ModelOverrideList itemPropertyOverrides, boolean hasDepth, @Nullable Identifier quadTransformId) {
 			meshBuilder = RENDERER.meshBuilder();
 			finder = RENDERER.materialFinder();
 			emitter = meshBuilder.getEmitter();
@@ -211,6 +244,7 @@ public class JmxBakedModel implements BakedModel, FabricBakedModel, Transformabl
 			this.isSideLit = isSideLit;
 			this.transformation = transformation;
 			this.hasDepth = hasDepth;
+			this.quadTransformId = quadTransformId;
 		}
 
 		public JmxBakedModel.Builder setParticle(Sprite sprite) {
@@ -221,9 +255,18 @@ public class JmxBakedModel implements BakedModel, FabricBakedModel, Transformabl
 		public BakedModel build() {
 			if (particleTexture == null) {
 				throw new RuntimeException("Missing particle!");
-			} else {
-				return new JmxBakedModel(meshBuilder.build(), usesAo, isSideLit, particleTexture, transformation, itemPropertyOverrides, hasDepth);
 			}
+			QuadTransformRegistry.QuadTransformSource quadTransformSupplier;
+			if (quadTransformId != null) {
+				quadTransformSupplier = QuadTransformRegistry.INSTANCE.getQuadTransform(quadTransformId);
+				if (quadTransformSupplier == null) {
+					throw new IllegalStateException("No quad transform is registered with ID " + quadTransformId);
+				}
+			} else {
+				quadTransformSupplier = null;
+			}
+
+			return new JmxBakedModel(meshBuilder.build(), usesAo, isSideLit, particleTexture, transformation, itemPropertyOverrides, hasDepth, quadTransformSupplier);
 		}
 
 		private static final BakedQuadFactory QUADFACTORY = new BakedQuadFactory();

--- a/src/main/java/grondag/jmx/mixin/MixinJsonUnbakedModel.java
+++ b/src/main/java/grondag/jmx/mixin/MixinJsonUnbakedModel.java
@@ -244,7 +244,7 @@ public abstract class MixinJsonUnbakedModel implements JsonUnbakedModelExt {
 		final Sprite particleSprite = spriteFunc.apply(me.resolveSprite("particle"));
 		final Function<String, Sprite> innerSpriteFunc = s -> spriteFunc.apply(me.resolveSprite(s));
 
-		final JmxBakedModel.Builder builder = (new JmxBakedModel.Builder(me, compileOverrides(modelLoader, unbakedModel), hasDepth))
+		final JmxBakedModel.Builder builder = (new JmxBakedModel.Builder(me, compileOverrides(modelLoader, unbakedModel), hasDepth, jmxModelExt.getQuadTransformId()))
 				.setParticle(particleSprite);
 		final Iterator<ModelElement> elements = me.getElements().iterator();
 		while (elements.hasNext()) {


### PR DESCRIPTION
This PR adds quad transform support to JMX models. Mods that depend on JMX can register a quad transform for an identifier, then that identifier can be referenced from model files. The quad transform identifier can be different for FREX and non-FREX, if desired. An example mod using this feature is available here: https://github.com/alex5nader/jmx_test_mod.

I've marked this PR as WIP because I'm not sure if my quad transform registry implementation is ideal.