### PR TITLE
Fix typo in models

### DIFF
--- a/src/main/resources/assets/jmx/models/block/2/jmx_fence_inventory.json
+++ b/src/main/resources/assets/jmx/models/block/2/jmx_fence_inventory.json
@@ -8,88 +8,88 @@
     "from": [ 6, 0, 0 ], "to": [ 10, 16, 4 ], "faces": {
     "down": {
       "uv": [ 6, 0, 10, 4 ], "texture": "#texture", "cullface": "down", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "up": {
       "uv": [ 6, 0, 10, 4 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "north": {
       "uv": [ 6, 0, 10, 16 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "south": {
       "uv": [ 6, 0, 10, 16 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "west": {
       "uv": [ 0, 0, 4, 16 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "east": {
       "uv": [ 0, 0, 4, 16 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }
   }, "__comment": "Left post"
   }, {
     "from": [ 6, 0, 12 ], "to": [ 10, 16, 16 ], "faces": {
       "down": {
         "uv": [ 6, 12, 10, 16 ], "texture": "#texture", "cullface": "down", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "up": {
         "uv": [ 6, 12, 10, 16 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "north": {
         "uv": [ 6, 0, 10, 16 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "south": {
         "uv": [ 6, 0, 10, 16 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "west": {
         "uv": [ 12, 0, 16, 16 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "east": {
         "uv": [ 12, 0, 16, 16 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }
     }, "__comment": "Right post"
   }, {
     "from": [ 7, 13, -2 ], "to": [ 9, 15, 18 ], "faces": {
       "down": {
         "uv": [ 7, 0, 9, 16 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "up": {
         "uv": [ 7, 0, 9, 16 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "north": {
         "uv": [ 7, 1, 9, 3 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "south": {
         "uv": [ 7, 1, 9, 3 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "west": {
         "uv": [ 0, 1, 16, 3 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "east": {
         "uv": [ 0, 1, 16, 3 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }
     }, "__comment": "Top bar"
   }, {
     "from": [ 7, 5, -2 ], "to": [ 9, 7, 18 ], "faces": {
       "down": {
         "uv": [ 7, 0, 9, 16 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "up": {
         "uv": [ 7, 0, 9, 16 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "north": {
         "uv": [ 7, 9, 9, 11 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "south": {
         "uv": [ 7, 9, 9, 11 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "west": {
         "uv": [ 0, 9, 16, 11 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "east": {
         "uv": [ 0, 9, 16, 11 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }
     }, "__comment": "Lower bar"
   }

--- a/src/main/resources/assets/jmx/models/block/2/jmx_fence_post.json
+++ b/src/main/resources/assets/jmx/models/block/2/jmx_fence_post.json
@@ -4,22 +4,22 @@
     "from": [ 6, 0, 6 ], "to": [ 10, 16, 10 ], "faces": {
     "down": {
       "uv": [ 6, 6, 10, 10 ], "texture": "#texture", "cullface": "down", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "up": {
       "uv": [ 6, 6, 10, 10 ], "texture": "#texture", "cullface": "up", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "north": {
       "uv": [ 6, 0, 10, 16 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "south": {
       "uv": [ 6, 0, 10, 16 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "west": {
       "uv": [ 6, 0, 10, 16 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "east": {
       "uv": [ 6, 0, 10, 16 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }
   }, "__comment": "Center post"
   }

--- a/src/main/resources/assets/jmx/models/block/2/jmx_fence_side.json
+++ b/src/main/resources/assets/jmx/models/block/2/jmx_fence_side.json
@@ -4,38 +4,38 @@
     "from": [ 7, 12, 0 ], "to": [ 9, 15, 9 ], "faces": {
     "down": {
       "uv": [ 7, 0, 9, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "up": {
       "uv": [ 7, 0, 9, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "north": {
       "uv": [ 7, 1, 9, 4 ], "texture": "#texture", "cullface": "north", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "west": {
       "uv": [ 0, 1, 9, 4 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "east": {
       "uv": [ 0, 1, 9, 4 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }
   }, "__comment": "top bar"
   }, {
     "from": [ 7, 6, 0 ], "to": [ 9, 9, 9 ], "faces": {
       "down": {
         "uv": [ 7, 0, 9, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "up": {
         "uv": [ 7, 0, 9, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "north": {
         "uv": [ 7, 7, 9, 10 ], "texture": "#texture", "cullface": "north", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "west": {
         "uv": [ 0, 7, 9, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "east": {
         "uv": [ 0, 7, 9, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }
     }, "__comment": "lower bar"
   }

--- a/src/main/resources/assets/jmx/models/block/2/jmx_template_fence_gate.json
+++ b/src/main/resources/assets/jmx/models/block/2/jmx_template_fence_gate.json
@@ -7,152 +7,152 @@
     "__comment": "Left-hand post", "from": [ 0, 5, 7 ], "to": [ 2, 16, 9 ], "faces": {
     "down": {
       "uv": [ 0, 7, 2, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "up": {
       "uv": [ 0, 7, 2, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "north": {
       "uv": [ 0, 0, 2, 11 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "south": {
       "uv": [ 0, 0, 2, 11 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "west": {
       "uv": [ 7, 0, 9, 11 ], "texture": "#texture", "cullface": "west", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "east": {
       "uv": [ 7, 0, 9, 11 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }
   }
   }, {
     "__comment": "Right-hand post", "from": [ 14, 5, 7 ], "to": [ 16, 16, 9 ], "faces": {
       "down": {
         "uv": [ 14, 7, 16, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "up": {
         "uv": [ 14, 7, 16, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "north": {
         "uv": [ 14, 0, 16, 11 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "south": {
         "uv": [ 14, 0, 16, 11 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "west": {
         "uv": [ 7, 0, 9, 11 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "east": {
         "uv": [ 7, 0, 9, 11 ], "texture": "#texture", "cullface": "east", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }
     }
   }, {
     "__comment": "Inner vertical post of left-hand gate door", "from": [ 6, 6, 7 ], "to": [ 8, 15, 9 ], "faces": {
       "down": {
         "uv": [ 6, 7, 8, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "up": {
         "uv": [ 6, 7, 8, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "north": {
         "uv": [ 6, 1, 8, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "south": {
         "uv": [ 6, 1, 8, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "west": {
         "uv": [ 7, 1, 9, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "east": {
         "uv": [ 7, 1, 9, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }
     }
   }, {
     "__comment": "Inner vertical post of right-hand gate door", "from": [ 8, 6, 7 ], "to": [ 10, 15, 9 ], "faces": {
       "down": {
         "uv": [ 8, 7, 10, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "up": {
         "uv": [ 8, 7, 10, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "north": {
         "uv": [ 8, 1, 10, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "south": {
         "uv": [ 8, 1, 10, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "west": {
         "uv": [ 7, 1, 9, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "east": {
         "uv": [ 7, 1, 9, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }
     }
   }, {
     "__comment": "Lower horizontal bar of left-hand gate door", "from": [ 2, 6, 7 ], "to": [ 6, 9, 9 ], "faces": {
       "down": {
         "uv": [ 2, 7, 6, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "up": {
         "uv": [ 2, 7, 6, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "north": {
         "uv": [ 2, 7, 6, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "south": {
         "uv": [ 2, 7, 6, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }
     }
   }, {
     "__comment": "Upper horizontal bar of left-hand gate door", "from": [ 2, 12, 7 ], "to": [ 6, 15, 9 ], "faces": {
       "down": {
         "uv": [ 2, 7, 6, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "up": {
         "uv": [ 2, 7, 6, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "north": {
         "uv": [ 2, 1, 6, 4 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "south": {
         "uv": [ 2, 1, 6, 4 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }
     }
   }, {
     "__comment": "Lower horizontal bar of right-hand gate door", "from": [ 10, 6, 7 ], "to": [ 14, 9, 9 ], "faces": {
       "down": {
         "uv": [ 10, 7, 14, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "up": {
         "uv": [ 10, 7, 14, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "north": {
         "uv": [ 10, 7, 14, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "south": {
         "uv": [ 10, 7, 14, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }
     }
   }, {
     "__comment": "Upper horizontal bar of right-hand gate door", "from": [ 10, 12, 7 ], "to": [ 14, 15, 9 ], "faces": {
       "down": {
         "uv": [ 10, 7, 14, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "up": {
         "uv": [ 10, 7, 14, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "north": {
         "uv": [ 10, 1, 14, 4 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "south": {
         "uv": [ 10, 1, 14, 4 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }
     }
   }

--- a/src/main/resources/assets/jmx/models/block/2/jmx_template_fence_gate_open.json
+++ b/src/main/resources/assets/jmx/models/block/2/jmx_template_fence_gate_open.json
@@ -4,152 +4,152 @@
     "__comment": "Left-hand post", "from": [ 0, 5, 7 ], "to": [ 2, 16, 9 ], "faces": {
     "down": {
       "uv": [ 0, 7, 2, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "up": {
       "uv": [ 0, 7, 2, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "north": {
       "uv": [ 0, 0, 2, 11 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "south": {
       "uv": [ 0, 0, 2, 11 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "west": {
       "uv": [ 7, 0, 9, 11 ], "texture": "#texture", "cullface": "west", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "east": {
       "uv": [ 7, 0, 9, 11 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }
   }
   }, {
     "__comment": "Right-hand post", "from": [ 14, 5, 7 ], "to": [ 16, 16, 9 ], "faces": {
       "down": {
         "uv": [ 14, 7, 16, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "up": {
         "uv": [ 14, 7, 16, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "north": {
         "uv": [ 14, 0, 16, 11 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "south": {
         "uv": [ 14, 0, 16, 11 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "west": {
         "uv": [ 7, 0, 9, 11 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "east": {
         "uv": [ 7, 0, 9, 11 ], "texture": "#texture", "cullface": "east", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }
     }
   }, {
     "__comment": "Inner vertical post of left-hand gate door", "from": [ 0, 6, 13 ], "to": [ 2, 15, 15 ], "faces": {
       "down": {
         "uv": [ 0, 13, 2, 15 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "up": {
         "uv": [ 0, 13, 2, 15 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "north": {
         "uv": [ 0, 1, 2, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "south": {
         "uv": [ 0, 1, 2, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "west": {
         "uv": [ 13, 1, 15, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "east": {
         "uv": [ 13, 1, 15, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }
     }
   }, {
     "__comment": "Inner vertical post of right-hand gate door", "from": [ 14, 6, 13 ], "to": [ 16, 15, 15 ], "faces": {
       "down": {
         "uv": [ 14, 13, 16, 15 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "up": {
         "uv": [ 14, 13, 16, 15 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "north": {
         "uv": [ 14, 1, 16, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "south": {
         "uv": [ 14, 1, 16, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "west": {
         "uv": [ 13, 1, 15, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "east": {
         "uv": [ 13, 1, 15, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }
     }
   }, {
     "__comment": "Lower horizontal bar of left-hand gate door", "from": [ 0, 6, 9 ], "to": [ 2, 9, 13 ], "faces": {
       "down": {
         "uv": [ 0, 9, 2, 13 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "up": {
         "uv": [ 0, 9, 2, 13 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "west": {
         "uv": [ 13, 7, 15, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "east": {
         "uv": [ 13, 7, 15, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }
     }
   }, {
     "__comment": "Upper horizontal bar of left-hand gate door", "from": [ 0, 12, 9 ], "to": [ 2, 15, 13 ], "faces": {
       "down": {
         "uv": [ 0, 9, 2, 13 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "up": {
         "uv": [ 0, 9, 2, 13 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "west": {
         "uv": [ 13, 1, 15, 4 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "east": {
         "uv": [ 13, 1, 15, 4 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }
     }
   }, {
     "__comment": "Lower horizontal bar of left-hand gate door", "from": [ 14, 6, 9 ], "to": [ 16, 9, 13 ], "faces": {
       "down": {
         "uv": [ 14, 9, 16, 13 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "up": {
         "uv": [ 14, 9, 16, 13 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "west": {
         "uv": [ 13, 7, 15, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "east": {
         "uv": [ 13, 7, 15, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }
     }
   }, {
     "__comment": "Upper horizontal bar of left-hand gate door", "from": [ 14, 12, 9 ], "to": [ 16, 15, 13 ], "faces": {
       "down": {
         "uv": [ 14, 9, 16, 13 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "up": {
         "uv": [ 14, 9, 16, 13 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "west": {
         "uv": [ 13, 1, 15, 4 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "east": {
         "uv": [ 13, 1, 15, 4 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }
     }
   }

--- a/src/main/resources/assets/jmx/models/block/2/jmx_template_fence_gate_wall.json
+++ b/src/main/resources/assets/jmx/models/block/2/jmx_template_fence_gate_wall.json
@@ -5,104 +5,104 @@
     "__comment": "Left-hand post", "from": [ 0, 2, 7 ], "to": [ 2, 13, 9 ], "faces": {
     "down": {
       "uv": [ 0, 7, 2, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "up": {
       "uv": [ 0, 7, 2, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "north": {
       "uv": [ 0, 0, 2, 11 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "south": {
       "uv": [ 0, 0, 2, 11 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "west": {
       "uv": [ 7, 0, 9, 11 ], "texture": "#texture", "cullface": "west", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "east": {
       "uv": [ 7, 0, 9, 11 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }
   }
   }, {
     "__comment": "Right-hand post", "from": [ 14, 2, 7 ], "to": [ 16, 13, 9 ], "faces": {
       "down": {
         "uv": [ 14, 7, 16, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "up": {
         "uv": [ 14, 7, 16, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "north": {
         "uv": [ 14, 0, 16, 11 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "south": {
         "uv": [ 14, 0, 16, 11 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "west": {
         "uv": [ 7, 0, 9, 11 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "east": {
         "uv": [ 7, 0, 9, 11 ], "texture": "#texture", "cullface": "east", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }
     }
   }, {
     "__comment": "Inner vertical post of left-hand gate door", "from": [ 6, 3, 7 ], "to": [ 8, 12, 9 ], "faces": {
       "down": {
         "uv": [ 6, 7, 8, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "up": {
         "uv": [ 6, 7, 8, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "north": {
         "uv": [ 6, 1, 8, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "south": {
         "uv": [ 6, 1, 8, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "west": {
         "uv": [ 7, 1, 9, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "east": {
         "uv": [ 7, 1, 9, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }
     }
   }, {
     "__comment": "Inner vertical post of right-hand gate door", "from": [ 8, 3, 7 ], "to": [ 10, 12, 9 ], "faces": {
       "down": {
         "uv": [ 8, 7, 10, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "up": {
         "uv": [ 8, 7, 10, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "north": {
         "uv": [ 8, 1, 10, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "south": {
         "uv": [ 8, 1, 10, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "west": {
         "uv": [ 7, 1, 9, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "east": {
         "uv": [ 7, 1, 9, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }
     }
   }, {
     "__comment": "Lower horizontal bar of left-hand gate door", "from": [ 2, 3, 7 ], "to": [ 6, 6, 9 ], "faces": {
       "down": {
         "uv": [ 2, 7, 6, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "up": {
         "uv": [ 2, 7, 6, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "north": {
         "uv": [ 2, 7, 6, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "south": {
         "uv": [ 2, 7, 6, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }
     }
   }, {

--- a/src/main/resources/assets/jmx/models/block/2/jmx_template_fence_gate_wall_open.json
+++ b/src/main/resources/assets/jmx/models/block/2/jmx_template_fence_gate_wall_open.json
@@ -5,152 +5,152 @@
     "__comment": "Left-hand post", "from": [ 0, 2, 7 ], "to": [ 2, 13, 9 ], "faces": {
     "down": {
       "uv": [ 0, 7, 2, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "up": {
       "uv": [ 0, 7, 2, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "north": {
       "uv": [ 0, 0, 2, 11 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "south": {
       "uv": [ 0, 0, 2, 11 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "west": {
       "uv": [ 7, 0, 9, 11 ], "texture": "#texture", "cullface": "west", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "east": {
       "uv": [ 7, 0, 9, 11 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }
   }
   }, {
     "__comment": "Right-hand post", "from": [ 14, 2, 7 ], "to": [ 16, 13, 9 ], "faces": {
       "down": {
         "uv": [ 14, 7, 16, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "up": {
         "uv": [ 14, 7, 16, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "north": {
         "uv": [ 14, 0, 16, 11 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "south": {
         "uv": [ 14, 0, 16, 11 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "west": {
         "uv": [ 7, 0, 9, 11 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "east": {
         "uv": [ 7, 0, 9, 11 ], "texture": "#texture", "cullface": "east", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }
     }
   }, {
     "__comment": "Inner vertical post of left-hand gate door", "from": [ 0, 3, 13 ], "to": [ 2, 12, 15 ], "faces": {
       "down": {
         "uv": [ 0, 13, 2, 15 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "up": {
         "uv": [ 0, 13, 2, 15 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "north": {
         "uv": [ 0, 1, 2, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "south": {
         "uv": [ 0, 1, 2, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "west": {
         "uv": [ 13, 1, 15, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "east": {
         "uv": [ 13, 1, 15, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }
     }
   }, {
     "__comment": "Inner vertical post of right-hand gate door", "from": [ 14, 3, 13 ], "to": [ 16, 12, 15 ], "faces": {
       "down": {
         "uv": [ 14, 13, 16, 15 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "up": {
         "uv": [ 14, 13, 16, 15 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "north": {
         "uv": [ 14, 1, 16, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "south": {
         "uv": [ 14, 1, 16, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "west": {
         "uv": [ 13, 1, 15, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "east": {
         "uv": [ 13, 1, 15, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }
     }
   }, {
     "__comment": "Lower horizontal bar of left-hand gate door", "from": [ 0, 3, 9 ], "to": [ 2, 6, 13 ], "faces": {
       "down": {
         "uv": [ 0, 9, 2, 13 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "up": {
         "uv": [ 0, 9, 2, 13 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "west": {
         "uv": [ 13, 7, 15, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "east": {
         "uv": [ 13, 7, 15, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }
     }
   }, {
     "__comment": "Upper horizontal bar of left-hand gate door", "from": [ 0, 9, 9 ], "to": [ 2, 12, 13 ], "faces": {
       "down": {
         "uv": [ 0, 9, 2, 13 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "up": {
         "uv": [ 0, 9, 2, 13 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "west": {
         "uv": [ 13, 1, 15, 4 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "east": {
         "uv": [ 13, 1, 15, 4 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }
     }
   }, {
     "__comment": "Lower horizontal bar of left-hand gate door", "from": [ 14, 3, 9 ], "to": [ 16, 6, 13 ], "faces": {
       "down": {
         "uv": [ 14, 9, 16, 13 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "up": {
         "uv": [ 14, 9, 16, 13 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "west": {
         "uv": [ 13, 7, 15, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "east": {
         "uv": [ 13, 7, 15, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }
     }
   }, {
     "__comment": "Upper horizontal bar of left-hand gate door", "from": [ 14, 9, 9 ], "to": [ 16, 12, 13 ], "faces": {
       "down": {
         "uv": [ 14, 9, 16, 13 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "up": {
         "uv": [ 14, 9, 16, 13 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "west": {
         "uv": [ 13, 1, 15, 4 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "east": {
         "uv": [ 13, 1, 15, 4 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }
     }
   }

--- a/src/main/resources/assets/jmx/models/block/2/jmx_template_orientable_trapdoor_bottom.json
+++ b/src/main/resources/assets/jmx/models/block/2/jmx_template_orientable_trapdoor_bottom.json
@@ -5,22 +5,22 @@
     "from": [ 0, 0, 0 ], "to": [ 16, 3, 16 ], "faces": {
     "down": {
       "uv": [ 0, 0, 16, 16 ], "texture": "#texture", "cullface": "down", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "up": {
       "uv": [ 0, 16, 16, 0 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "north": {
       "uv": [ 0, 0, 16, 3 ], "texture": "#texture", "cullface": "north", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "south": {
       "uv": [ 0, 0, 16, 3 ], "texture": "#texture", "cullface": "south", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "west": {
       "uv": [ 0, 0, 16, 3 ], "texture": "#texture", "cullface": "west", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "east": {
       "uv": [ 0, 0, 16, 3 ], "texture": "#texture", "cullface": "east", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }
   }
   }

--- a/src/main/resources/assets/jmx/models/block/2/jmx_template_orientable_trapdoor_open.json
+++ b/src/main/resources/assets/jmx/models/block/2/jmx_template_orientable_trapdoor_open.json
@@ -4,22 +4,22 @@
     "from": [ 0, 0, 13 ], "to": [ 16, 16, 16 ], "faces": {
     "down": {
       "uv": [ 0, 0, 16, 3 ], "texture": "#texture", "cullface": "down", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "up": {
       "uv": [ 0, 3, 16, 0 ], "texture": "#texture", "cullface": "up", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "north": {
       "uv": [ 0, 16, 16, 0 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "south": {
       "uv": [ 0, 16, 16, 0 ], "texture": "#texture", "cullface": "south", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "west": {
       "uv": [ 0, 0, 16, 3 ], "rotation": 90, "texture": "#texture", "cullface": "west", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "east": {
       "uv": [ 0, 3, 16, 0 ], "rotation": 90, "texture": "#texture", "cullface": "east", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }
   }
   }

--- a/src/main/resources/assets/jmx/models/block/2/jmx_template_orientable_trapdoor_top.json
+++ b/src/main/resources/assets/jmx/models/block/2/jmx_template_orientable_trapdoor_top.json
@@ -4,22 +4,22 @@
     "from": [ 0, 13, 0 ], "to": [ 16, 16, 16 ], "faces": {
     "down": {
       "uv": [ 0, 0, 16, 16 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "up": {
       "uv": [ 0, 16, 16, 0 ], "texture": "#texture", "cullface": "up", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "north": {
       "uv": [ 0, 0, 16, 3 ], "texture": "#texture", "cullface": "north", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "south": {
       "uv": [ 0, 0, 16, 3 ], "texture": "#texture", "cullface": "south", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "west": {
       "uv": [ 0, 0, 16, 3 ], "texture": "#texture", "cullface": "west", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "east": {
       "uv": [ 0, 0, 16, 3 ], "texture": "#texture", "cullface": "east", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }
   }
   }

--- a/src/main/resources/assets/jmx/models/block/2/jmx_template_trapdoor_bottom.json
+++ b/src/main/resources/assets/jmx/models/block/2/jmx_template_trapdoor_bottom.json
@@ -5,22 +5,22 @@
     "from": [ 0, 0, 0 ], "to": [ 16, 3, 16 ], "faces": {
     "down": {
       "uv": [ 0, 0, 16, 16 ], "texture": "#texture", "cullface": "down", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "up": {
       "uv": [ 0, 0, 16, 16 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "north": {
       "uv": [ 0, 16, 16, 13 ], "texture": "#texture", "cullface": "north", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "south": {
       "uv": [ 0, 16, 16, 13 ], "texture": "#texture", "cullface": "south", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "west": {
       "uv": [ 0, 16, 16, 13 ], "texture": "#texture", "cullface": "west", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "east": {
       "uv": [ 0, 16, 16, 13 ], "texture": "#texture", "cullface": "east", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }
   }
   }

--- a/src/main/resources/assets/jmx/models/block/2/jmx_template_trapdoor_open.json
+++ b/src/main/resources/assets/jmx/models/block/2/jmx_template_trapdoor_open.json
@@ -4,22 +4,22 @@
     "from": [ 0, 0, 13 ], "to": [ 16, 16, 16 ], "faces": {
     "down": {
       "uv": [ 0, 13, 16, 16 ], "texture": "#texture", "cullface": "down", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "up": {
       "uv": [ 0, 16, 16, 13 ], "texture": "#texture", "cullface": "up", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "north": {
       "uv": [ 0, 0, 16, 16 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "south": {
       "uv": [ 0, 0, 16, 16 ], "texture": "#texture", "cullface": "south", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "west": {
       "uv": [ 16, 0, 13, 16 ], "texture": "#texture", "cullface": "west", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "east": {
       "uv": [ 13, 0, 16, 16 ], "texture": "#texture", "cullface": "east", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }
   }
   }

--- a/src/main/resources/assets/jmx/models/block/2/jmx_template_trapdoor_top.json
+++ b/src/main/resources/assets/jmx/models/block/2/jmx_template_trapdoor_top.json
@@ -4,22 +4,22 @@
     "from": [ 0, 13, 0 ], "to": [ 16, 16, 16 ], "faces": {
     "down": {
       "uv": [ 0, 0, 16, 16 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "up": {
       "uv": [ 0, 0, 16, 16 ], "texture": "#texture", "cullface": "up", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "north": {
       "uv": [ 0, 16, 16, 13 ], "texture": "#texture", "cullface": "north", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "south": {
       "uv": [ 0, 16, 16, 13 ], "texture": "#texture", "cullface": "south", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "west": {
       "uv": [ 0, 16, 16, 13 ], "texture": "#texture", "cullface": "west", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "east": {
       "uv": [ 0, 16, 16, 13 ], "texture": "#texture", "cullface": "east", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }
   }
   }

--- a/src/main/resources/assets/jmx/models/block/3/jmx_fence_inventory.json
+++ b/src/main/resources/assets/jmx/models/block/3/jmx_fence_inventory.json
@@ -8,88 +8,88 @@
     "from": [ 6, 0, 0 ], "to": [ 10, 16, 4 ], "faces": {
     "down": {
       "uv": [ 6, 0, 10, 4 ], "texture": "#texture", "cullface": "down", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "up": {
       "uv": [ 6, 0, 10, 4 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "north": {
       "uv": [ 6, 0, 10, 16 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "south": {
       "uv": [ 6, 0, 10, 16 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "west": {
       "uv": [ 0, 0, 4, 16 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "east": {
       "uv": [ 0, 0, 4, 16 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }
   }, "__comment": "Left post"
   }, {
     "from": [ 6, 0, 12 ], "to": [ 10, 16, 16 ], "faces": {
       "down": {
         "uv": [ 6, 12, 10, 16 ], "texture": "#texture", "cullface": "down", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "up": {
         "uv": [ 6, 12, 10, 16 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "north": {
         "uv": [ 6, 0, 10, 16 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "south": {
         "uv": [ 6, 0, 10, 16 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "west": {
         "uv": [ 12, 0, 16, 16 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "east": {
         "uv": [ 12, 0, 16, 16 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }
     }, "__comment": "Right post"
   }, {
     "from": [ 7, 13, -2 ], "to": [ 9, 15, 18 ], "faces": {
       "down": {
         "uv": [ 7, 0, 9, 16 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "up": {
         "uv": [ 7, 0, 9, 16 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "north": {
         "uv": [ 7, 1, 9, 3 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "south": {
         "uv": [ 7, 1, 9, 3 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "west": {
         "uv": [ 0, 1, 16, 3 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "east": {
         "uv": [ 0, 1, 16, 3 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }
     }, "__comment": "Top bar"
   }, {
     "from": [ 7, 5, -2 ], "to": [ 9, 7, 18 ], "faces": {
       "down": {
         "uv": [ 7, 0, 9, 16 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "up": {
         "uv": [ 7, 0, 9, 16 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "north": {
         "uv": [ 7, 9, 9, 11 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "south": {
         "uv": [ 7, 9, 9, 11 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "west": {
         "uv": [ 0, 9, 16, 11 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "east": {
         "uv": [ 0, 9, 16, 11 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }
     }, "__comment": "Lower bar"
   }

--- a/src/main/resources/assets/jmx/models/block/3/jmx_fence_post.json
+++ b/src/main/resources/assets/jmx/models/block/3/jmx_fence_post.json
@@ -4,22 +4,22 @@
     "from": [ 6, 0, 6 ], "to": [ 10, 16, 10 ], "faces": {
     "down": {
       "uv": [ 6, 6, 10, 10 ], "texture": "#texture", "cullface": "down", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "up": {
       "uv": [ 6, 6, 10, 10 ], "texture": "#texture", "cullface": "up", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "north": {
       "uv": [ 6, 0, 10, 16 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "south": {
       "uv": [ 6, 0, 10, 16 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "west": {
       "uv": [ 6, 0, 10, 16 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "east": {
       "uv": [ 6, 0, 10, 16 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }
   }, "__comment": "Center post"
   }

--- a/src/main/resources/assets/jmx/models/block/3/jmx_fence_side.json
+++ b/src/main/resources/assets/jmx/models/block/3/jmx_fence_side.json
@@ -4,38 +4,38 @@
     "from": [ 7, 12, 0 ], "to": [ 9, 15, 9 ], "faces": {
     "down": {
       "uv": [ 7, 0, 9, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "up": {
       "uv": [ 7, 0, 9, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "north": {
       "uv": [ 7, 1, 9, 4 ], "texture": "#texture", "cullface": "north", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "west": {
       "uv": [ 0, 1, 9, 4 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "east": {
       "uv": [ 0, 1, 9, 4 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }
   }, "__comment": "top bar"
   }, {
     "from": [ 7, 6, 0 ], "to": [ 9, 9, 9 ], "faces": {
       "down": {
         "uv": [ 7, 0, 9, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "up": {
         "uv": [ 7, 0, 9, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "north": {
         "uv": [ 7, 7, 9, 10 ], "texture": "#texture", "cullface": "north", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "west": {
         "uv": [ 0, 7, 9, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "east": {
         "uv": [ 0, 7, 9, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }
     }, "__comment": "lower bar"
   }

--- a/src/main/resources/assets/jmx/models/block/3/jmx_template_fence_gate.json
+++ b/src/main/resources/assets/jmx/models/block/3/jmx_template_fence_gate.json
@@ -7,152 +7,152 @@
     "__comment": "Left-hand post", "from": [ 0, 5, 7 ], "to": [ 2, 16, 9 ], "faces": {
     "down": {
       "uv": [ 0, 7, 2, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "up": {
       "uv": [ 0, 7, 2, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "north": {
       "uv": [ 0, 0, 2, 11 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "south": {
       "uv": [ 0, 0, 2, 11 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "west": {
       "uv": [ 7, 0, 9, 11 ], "texture": "#texture", "cullface": "west", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "east": {
       "uv": [ 7, 0, 9, 11 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }
   }
   }, {
     "__comment": "Right-hand post", "from": [ 14, 5, 7 ], "to": [ 16, 16, 9 ], "faces": {
       "down": {
         "uv": [ 14, 7, 16, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "up": {
         "uv": [ 14, 7, 16, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "north": {
         "uv": [ 14, 0, 16, 11 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "south": {
         "uv": [ 14, 0, 16, 11 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "west": {
         "uv": [ 7, 0, 9, 11 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "east": {
         "uv": [ 7, 0, 9, 11 ], "texture": "#texture", "cullface": "east", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }
     }
   }, {
     "__comment": "Inner vertical post of left-hand gate door", "from": [ 6, 6, 7 ], "to": [ 8, 15, 9 ], "faces": {
       "down": {
         "uv": [ 6, 7, 8, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "up": {
         "uv": [ 6, 7, 8, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "north": {
         "uv": [ 6, 1, 8, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "south": {
         "uv": [ 6, 1, 8, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "west": {
         "uv": [ 7, 1, 9, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "east": {
         "uv": [ 7, 1, 9, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }
     }
   }, {
     "__comment": "Inner vertical post of right-hand gate door", "from": [ 8, 6, 7 ], "to": [ 10, 15, 9 ], "faces": {
       "down": {
         "uv": [ 8, 7, 10, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "up": {
         "uv": [ 8, 7, 10, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "north": {
         "uv": [ 8, 1, 10, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "south": {
         "uv": [ 8, 1, 10, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "west": {
         "uv": [ 7, 1, 9, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "east": {
         "uv": [ 7, 1, 9, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }
     }
   }, {
     "__comment": "Lower horizontal bar of left-hand gate door", "from": [ 2, 6, 7 ], "to": [ 6, 9, 9 ], "faces": {
       "down": {
         "uv": [ 2, 7, 6, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "up": {
         "uv": [ 2, 7, 6, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "north": {
         "uv": [ 2, 7, 6, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "south": {
         "uv": [ 2, 7, 6, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }
     }
   }, {
     "__comment": "Upper horizontal bar of left-hand gate door", "from": [ 2, 12, 7 ], "to": [ 6, 15, 9 ], "faces": {
       "down": {
         "uv": [ 2, 7, 6, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "up": {
         "uv": [ 2, 7, 6, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "north": {
         "uv": [ 2, 1, 6, 4 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "south": {
         "uv": [ 2, 1, 6, 4 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }
     }
   }, {
     "__comment": "Lower horizontal bar of right-hand gate door", "from": [ 10, 6, 7 ], "to": [ 14, 9, 9 ], "faces": {
       "down": {
         "uv": [ 10, 7, 14, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "up": {
         "uv": [ 10, 7, 14, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "north": {
         "uv": [ 10, 7, 14, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "south": {
         "uv": [ 10, 7, 14, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }
     }
   }, {
     "__comment": "Upper horizontal bar of right-hand gate door", "from": [ 10, 12, 7 ], "to": [ 14, 15, 9 ], "faces": {
       "down": {
         "uv": [ 10, 7, 14, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "up": {
         "uv": [ 10, 7, 14, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "north": {
         "uv": [ 10, 1, 14, 4 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "south": {
         "uv": [ 10, 1, 14, 4 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }
     }
   }

--- a/src/main/resources/assets/jmx/models/block/3/jmx_template_fence_gate_open.json
+++ b/src/main/resources/assets/jmx/models/block/3/jmx_template_fence_gate_open.json
@@ -4,152 +4,152 @@
     "__comment": "Left-hand post", "from": [ 0, 5, 7 ], "to": [ 2, 16, 9 ], "faces": {
     "down": {
       "uv": [ 0, 7, 2, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "up": {
       "uv": [ 0, 7, 2, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "north": {
       "uv": [ 0, 0, 2, 11 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "south": {
       "uv": [ 0, 0, 2, 11 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "west": {
       "uv": [ 7, 0, 9, 11 ], "texture": "#texture", "cullface": "west", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "east": {
       "uv": [ 7, 0, 9, 11 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }
   }
   }, {
     "__comment": "Right-hand post", "from": [ 14, 5, 7 ], "to": [ 16, 16, 9 ], "faces": {
       "down": {
         "uv": [ 14, 7, 16, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "up": {
         "uv": [ 14, 7, 16, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "north": {
         "uv": [ 14, 0, 16, 11 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "south": {
         "uv": [ 14, 0, 16, 11 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "west": {
         "uv": [ 7, 0, 9, 11 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "east": {
         "uv": [ 7, 0, 9, 11 ], "texture": "#texture", "cullface": "east", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }
     }
   }, {
     "__comment": "Inner vertical post of left-hand gate door", "from": [ 0, 6, 13 ], "to": [ 2, 15, 15 ], "faces": {
       "down": {
         "uv": [ 0, 13, 2, 15 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "up": {
         "uv": [ 0, 13, 2, 15 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "north": {
         "uv": [ 0, 1, 2, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "south": {
         "uv": [ 0, 1, 2, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "west": {
         "uv": [ 13, 1, 15, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "east": {
         "uv": [ 13, 1, 15, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }
     }
   }, {
     "__comment": "Inner vertical post of right-hand gate door", "from": [ 14, 6, 13 ], "to": [ 16, 15, 15 ], "faces": {
       "down": {
         "uv": [ 14, 13, 16, 15 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "up": {
         "uv": [ 14, 13, 16, 15 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "north": {
         "uv": [ 14, 1, 16, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "south": {
         "uv": [ 14, 1, 16, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "west": {
         "uv": [ 13, 1, 15, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "east": {
         "uv": [ 13, 1, 15, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }
     }
   }, {
     "__comment": "Lower horizontal bar of left-hand gate door", "from": [ 0, 6, 9 ], "to": [ 2, 9, 13 ], "faces": {
       "down": {
         "uv": [ 0, 9, 2, 13 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "up": {
         "uv": [ 0, 9, 2, 13 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "west": {
         "uv": [ 13, 7, 15, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "east": {
         "uv": [ 13, 7, 15, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }
     }
   }, {
     "__comment": "Upper horizontal bar of left-hand gate door", "from": [ 0, 12, 9 ], "to": [ 2, 15, 13 ], "faces": {
       "down": {
         "uv": [ 0, 9, 2, 13 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "up": {
         "uv": [ 0, 9, 2, 13 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "west": {
         "uv": [ 13, 1, 15, 4 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "east": {
         "uv": [ 13, 1, 15, 4 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }
     }
   }, {
     "__comment": "Lower horizontal bar of left-hand gate door", "from": [ 14, 6, 9 ], "to": [ 16, 9, 13 ], "faces": {
       "down": {
         "uv": [ 14, 9, 16, 13 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "up": {
         "uv": [ 14, 9, 16, 13 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "west": {
         "uv": [ 13, 7, 15, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "east": {
         "uv": [ 13, 7, 15, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }
     }
   }, {
     "__comment": "Upper horizontal bar of left-hand gate door", "from": [ 14, 12, 9 ], "to": [ 16, 15, 13 ], "faces": {
       "down": {
         "uv": [ 14, 9, 16, 13 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "up": {
         "uv": [ 14, 9, 16, 13 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "west": {
         "uv": [ 13, 1, 15, 4 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "east": {
         "uv": [ 13, 1, 15, 4 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }
     }
   }

--- a/src/main/resources/assets/jmx/models/block/3/jmx_template_fence_gate_wall.json
+++ b/src/main/resources/assets/jmx/models/block/3/jmx_template_fence_gate_wall.json
@@ -5,104 +5,104 @@
     "__comment": "Left-hand post", "from": [ 0, 2, 7 ], "to": [ 2, 13, 9 ], "faces": {
     "down": {
       "uv": [ 0, 7, 2, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "up": {
       "uv": [ 0, 7, 2, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "north": {
       "uv": [ 0, 0, 2, 11 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "south": {
       "uv": [ 0, 0, 2, 11 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "west": {
       "uv": [ 7, 0, 9, 11 ], "texture": "#texture", "cullface": "west", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "east": {
       "uv": [ 7, 0, 9, 11 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }
   }
   }, {
     "__comment": "Right-hand post", "from": [ 14, 2, 7 ], "to": [ 16, 13, 9 ], "faces": {
       "down": {
         "uv": [ 14, 7, 16, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "up": {
         "uv": [ 14, 7, 16, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "north": {
         "uv": [ 14, 0, 16, 11 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "south": {
         "uv": [ 14, 0, 16, 11 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "west": {
         "uv": [ 7, 0, 9, 11 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "east": {
         "uv": [ 7, 0, 9, 11 ], "texture": "#texture", "cullface": "east", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }
     }
   }, {
     "__comment": "Inner vertical post of left-hand gate door", "from": [ 6, 3, 7 ], "to": [ 8, 12, 9 ], "faces": {
       "down": {
         "uv": [ 6, 7, 8, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "up": {
         "uv": [ 6, 7, 8, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "north": {
         "uv": [ 6, 1, 8, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "south": {
         "uv": [ 6, 1, 8, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "west": {
         "uv": [ 7, 1, 9, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "east": {
         "uv": [ 7, 1, 9, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }
     }
   }, {
     "__comment": "Inner vertical post of right-hand gate door", "from": [ 8, 3, 7 ], "to": [ 10, 12, 9 ], "faces": {
       "down": {
         "uv": [ 8, 7, 10, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "up": {
         "uv": [ 8, 7, 10, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "north": {
         "uv": [ 8, 1, 10, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "south": {
         "uv": [ 8, 1, 10, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "west": {
         "uv": [ 7, 1, 9, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "east": {
         "uv": [ 7, 1, 9, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }
     }
   }, {
     "__comment": "Lower horizontal bar of left-hand gate door", "from": [ 2, 3, 7 ], "to": [ 6, 6, 9 ], "faces": {
       "down": {
         "uv": [ 2, 7, 6, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "up": {
         "uv": [ 2, 7, 6, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "north": {
         "uv": [ 2, 7, 6, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "south": {
         "uv": [ 2, 7, 6, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }
     }
   }, {

--- a/src/main/resources/assets/jmx/models/block/3/jmx_template_fence_gate_wall_open.json
+++ b/src/main/resources/assets/jmx/models/block/3/jmx_template_fence_gate_wall_open.json
@@ -5,152 +5,152 @@
     "__comment": "Left-hand post", "from": [ 0, 2, 7 ], "to": [ 2, 13, 9 ], "faces": {
     "down": {
       "uv": [ 0, 7, 2, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "up": {
       "uv": [ 0, 7, 2, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "north": {
       "uv": [ 0, 0, 2, 11 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "south": {
       "uv": [ 0, 0, 2, 11 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "west": {
       "uv": [ 7, 0, 9, 11 ], "texture": "#texture", "cullface": "west", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "east": {
       "uv": [ 7, 0, 9, 11 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }
   }
   }, {
     "__comment": "Right-hand post", "from": [ 14, 2, 7 ], "to": [ 16, 13, 9 ], "faces": {
       "down": {
         "uv": [ 14, 7, 16, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "up": {
         "uv": [ 14, 7, 16, 9 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "north": {
         "uv": [ 14, 0, 16, 11 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "south": {
         "uv": [ 14, 0, 16, 11 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "west": {
         "uv": [ 7, 0, 9, 11 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "east": {
         "uv": [ 7, 0, 9, 11 ], "texture": "#texture", "cullface": "east", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }
     }
   }, {
     "__comment": "Inner vertical post of left-hand gate door", "from": [ 0, 3, 13 ], "to": [ 2, 12, 15 ], "faces": {
       "down": {
         "uv": [ 0, 13, 2, 15 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "up": {
         "uv": [ 0, 13, 2, 15 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "north": {
         "uv": [ 0, 1, 2, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "south": {
         "uv": [ 0, 1, 2, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "west": {
         "uv": [ 13, 1, 15, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "east": {
         "uv": [ 13, 1, 15, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }
     }
   }, {
     "__comment": "Inner vertical post of right-hand gate door", "from": [ 14, 3, 13 ], "to": [ 16, 12, 15 ], "faces": {
       "down": {
         "uv": [ 14, 13, 16, 15 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "up": {
         "uv": [ 14, 13, 16, 15 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "north": {
         "uv": [ 14, 1, 16, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "south": {
         "uv": [ 14, 1, 16, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "west": {
         "uv": [ 13, 1, 15, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "east": {
         "uv": [ 13, 1, 15, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }
     }
   }, {
     "__comment": "Lower horizontal bar of left-hand gate door", "from": [ 0, 3, 9 ], "to": [ 2, 6, 13 ], "faces": {
       "down": {
         "uv": [ 0, 9, 2, 13 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "up": {
         "uv": [ 0, 9, 2, 13 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "west": {
         "uv": [ 13, 7, 15, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "east": {
         "uv": [ 13, 7, 15, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }
     }
   }, {
     "__comment": "Upper horizontal bar of left-hand gate door", "from": [ 0, 9, 9 ], "to": [ 2, 12, 13 ], "faces": {
       "down": {
         "uv": [ 0, 9, 2, 13 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "up": {
         "uv": [ 0, 9, 2, 13 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "west": {
         "uv": [ 13, 1, 15, 4 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "east": {
         "uv": [ 13, 1, 15, 4 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }
     }
   }, {
     "__comment": "Lower horizontal bar of left-hand gate door", "from": [ 14, 3, 9 ], "to": [ 16, 6, 13 ], "faces": {
       "down": {
         "uv": [ 14, 9, 16, 13 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "up": {
         "uv": [ 14, 9, 16, 13 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "west": {
         "uv": [ 13, 7, 15, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "east": {
         "uv": [ 13, 7, 15, 10 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }
     }
   }, {
     "__comment": "Upper horizontal bar of left-hand gate door", "from": [ 14, 9, 9 ], "to": [ 16, 12, 13 ], "faces": {
       "down": {
         "uv": [ 14, 9, 16, 13 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "up": {
         "uv": [ 14, 9, 16, 13 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "west": {
         "uv": [ 13, 1, 15, 4 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }, "east": {
         "uv": [ 13, 1, 15, 4 ], "texture": "#texture", "jmx_material": "#jmx_material",
-        "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+        "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
       }
     }
   }

--- a/src/main/resources/assets/jmx/models/block/3/jmx_template_orientable_trapdoor_bottom.json
+++ b/src/main/resources/assets/jmx/models/block/3/jmx_template_orientable_trapdoor_bottom.json
@@ -5,22 +5,22 @@
     "from": [ 0, 0, 0 ], "to": [ 16, 3, 16 ], "faces": {
     "down": {
       "uv": [ 0, 0, 16, 16 ], "texture": "#texture", "cullface": "down", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "up": {
       "uv": [ 0, 16, 16, 0 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "north": {
       "uv": [ 0, 0, 16, 3 ], "texture": "#texture", "cullface": "north", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "south": {
       "uv": [ 0, 0, 16, 3 ], "texture": "#texture", "cullface": "south", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "west": {
       "uv": [ 0, 0, 16, 3 ], "texture": "#texture", "cullface": "west", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "east": {
       "uv": [ 0, 0, 16, 3 ], "texture": "#texture", "cullface": "east", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }
   }
   }

--- a/src/main/resources/assets/jmx/models/block/3/jmx_template_orientable_trapdoor_open.json
+++ b/src/main/resources/assets/jmx/models/block/3/jmx_template_orientable_trapdoor_open.json
@@ -4,22 +4,22 @@
     "from": [ 0, 0, 13 ], "to": [ 16, 16, 16 ], "faces": {
     "down": {
       "uv": [ 0, 0, 16, 3 ], "texture": "#texture", "cullface": "down", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "up": {
       "uv": [ 0, 3, 16, 0 ], "texture": "#texture", "cullface": "up", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "north": {
       "uv": [ 0, 16, 16, 0 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "south": {
       "uv": [ 0, 16, 16, 0 ], "texture": "#texture", "cullface": "south", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "west": {
       "uv": [ 0, 0, 16, 3 ], "rotation": 90, "texture": "#texture", "cullface": "west", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "east": {
       "uv": [ 0, 3, 16, 0 ], "rotation": 90, "texture": "#texture", "cullface": "east", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }
   }
   }

--- a/src/main/resources/assets/jmx/models/block/3/jmx_template_orientable_trapdoor_top.json
+++ b/src/main/resources/assets/jmx/models/block/3/jmx_template_orientable_trapdoor_top.json
@@ -4,22 +4,22 @@
     "from": [ 0, 13, 0 ], "to": [ 16, 16, 16 ], "faces": {
     "down": {
       "uv": [ 0, 0, 16, 16 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "up": {
       "uv": [ 0, 16, 16, 0 ], "texture": "#texture", "cullface": "up", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "north": {
       "uv": [ 0, 0, 16, 3 ], "texture": "#texture", "cullface": "north", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "south": {
       "uv": [ 0, 0, 16, 3 ], "texture": "#texture", "cullface": "south", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "west": {
       "uv": [ 0, 0, 16, 3 ], "texture": "#texture", "cullface": "west", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "east": {
       "uv": [ 0, 0, 16, 3 ], "texture": "#texture", "cullface": "east", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }
   }
   }

--- a/src/main/resources/assets/jmx/models/block/3/jmx_template_trapdoor_bottom.json
+++ b/src/main/resources/assets/jmx/models/block/3/jmx_template_trapdoor_bottom.json
@@ -5,22 +5,22 @@
     "from": [ 0, 0, 0 ], "to": [ 16, 3, 16 ], "faces": {
     "down": {
       "uv": [ 0, 0, 16, 16 ], "texture": "#texture", "cullface": "down", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "up": {
       "uv": [ 0, 0, 16, 16 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "north": {
       "uv": [ 0, 16, 16, 13 ], "texture": "#texture", "cullface": "north", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "south": {
       "uv": [ 0, 16, 16, 13 ], "texture": "#texture", "cullface": "south", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "west": {
       "uv": [ 0, 16, 16, 13 ], "texture": "#texture", "cullface": "west", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "east": {
       "uv": [ 0, 16, 16, 13 ], "texture": "#texture", "cullface": "east", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }
   }
   }

--- a/src/main/resources/assets/jmx/models/block/3/jmx_template_trapdoor_open.json
+++ b/src/main/resources/assets/jmx/models/block/3/jmx_template_trapdoor_open.json
@@ -4,22 +4,22 @@
     "from": [ 0, 0, 13 ], "to": [ 16, 16, 16 ], "faces": {
     "down": {
       "uv": [ 0, 13, 16, 16 ], "texture": "#texture", "cullface": "down", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "up": {
       "uv": [ 0, 16, 16, 13 ], "texture": "#texture", "cullface": "up", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "north": {
       "uv": [ 0, 0, 16, 16 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "south": {
       "uv": [ 0, 0, 16, 16 ], "texture": "#texture", "cullface": "south", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "west": {
       "uv": [ 16, 0, 13, 16 ], "texture": "#texture", "cullface": "west", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "east": {
       "uv": [ 13, 0, 16, 16 ], "texture": "#texture", "cullface": "east", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }
   }
   }

--- a/src/main/resources/assets/jmx/models/block/3/jmx_template_trapdoor_top.json
+++ b/src/main/resources/assets/jmx/models/block/3/jmx_template_trapdoor_top.json
@@ -4,22 +4,22 @@
     "from": [ 0, 13, 0 ], "to": [ 16, 16, 16 ], "faces": {
     "down": {
       "uv": [ 0, 0, 16, 16 ], "texture": "#texture", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "up": {
       "uv": [ 0, 0, 16, 16 ], "texture": "#texture", "cullface": "up", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "north": {
       "uv": [ 0, 16, 16, 13 ], "texture": "#texture", "cullface": "north", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "south": {
       "uv": [ 0, 16, 16, 13 ], "texture": "#texture", "cullface": "south", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "west": {
       "uv": [ 0, 16, 16, 13 ], "texture": "#texture", "cullface": "west", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }, "east": {
       "uv": [ 0, 16, 16, 13 ], "texture": "#texture", "cullface": "east", "jmx_material": "#jmx_material",
-      "layered_textures": [ { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" }, { "jmx_tex": "#jmx_texure" } ]
+      "layered_textures": [ { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" }, { "jmx_tex": "#jmx_texture" } ]
     }
   }
   }


### PR DESCRIPTION
Many builtin JMX models have the texture reference `#jmx_texure`, which is a typo of `#jmx_texture`. This PR changes all of these occurrences. 