### PR TITLE
Parent model generator + more parent models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ discarded textures
 notes.txt
 *.csv
 .mixin.out/audit/mixin_implementation_report.txt
+
+# symlinked vanilla assets
+src/main/resources/assets/vanilla_mc

--- a/scripts/jmx.ts
+++ b/scripts/jmx.ts
@@ -1,0 +1,46 @@
+// @ts-ignore
+import {Array, Partial, String, Dictionary, Number, Static, Boolean} from "https://raw.githubusercontent.com/alex5nader/runtypes/master/src/index.ts";
+import {
+    Face,
+    FacesOf,
+    ModelElementOf,
+    ModelOf,
+} from "./vanilla.ts";
+
+export type Layers = Static<typeof Layers>;
+export const Layers = Array(Dictionary(String));
+
+export type JmxTextures = Static<typeof JmxTextures>;
+export const JmxTextures = Dictionary(String).And(Partial({
+    layered_textures: Layers,
+}));
+
+export type JmxModelExt = Static<typeof JmxModelExt>;
+export const JmxModelExt = Partial({
+    textures: JmxTextures,
+    materials: Layers,
+    tags: Layers,
+    colors: Layers,
+});
+
+export type FaceLayer = Static<typeof FaceLayer>;
+export const FaceLayer = Partial({
+    texture: String,
+    material: String,
+    tag: String,
+    color: String,
+});
+
+export type JmxLayers = Static<typeof JmxLayers>;
+export const JmxLayers = Array(FaceLayer);
+
+export type FaceExt = Static<typeof FaceExt>;
+export const FaceExt = Face.And(Partial({
+    jmx_layers: JmxLayers,
+}));
+
+export type JmxModel = Static<typeof JmxModel>;
+export const JmxModel = ModelOf(ModelElementOf(FacesOf(FaceExt))).And(Partial({
+    jmx_version: Number,
+    jmx: JmxModelExt,
+}));

--- a/scripts/make_parent_models_v1.ts
+++ b/scripts/make_parent_models_v1.ts
@@ -1,0 +1,395 @@
+#!/usr/bin/env -S deno run --allow-read --allow-write --unstable
+
+import {Model} from "./vanilla.ts";
+import {JmxModel, Layers} from "./jmx.ts";
+
+import {existsSync, walkSync, ensureFileSync} from "https://deno.land/std@0.82.0/fs/mod.ts";
+import {assertEquals} from "https://deno.land/std@0.82.0/testing/asserts.ts";
+
+Deno.chdir("../src/main/resources/assets");
+
+//region Validate type definitions using known models
+// {
+//     function check(path: string) {
+//         const json = JSON.parse(Deno.readTextFileSync(path));
+//
+//         try {
+//             Model.check(json);
+//         } catch (e) {
+//             console.log('not valid: ' + path);
+//             console.log(e);
+//             console.log();
+//             return;
+//         }
+//
+//         let layered_textures = undefined;
+//         if (json.jmx && json.jmx.textures && json.jmx.textures.layered_textures) {
+//             layered_textures = json.jmx.textures.layered_textures;
+//             delete json.jmx.textures.layered_textures;
+//         }
+//
+//         try {
+//             JmxModel.check(json);
+//             if (layered_textures) {
+//                 Layers.check(layered_textures);
+//             }
+//         } catch (e) {
+//             console.log('not jmx valid: ' + path);
+//             console.log(e);
+//             console.log();
+//             return;
+//         }
+//
+//         const model = json as JmxModel;
+//
+//         if (layered_textures) {
+//             // @ts-ignore // guaranteed to be present from above
+//             model.jmx.textures.layered_textures = layered_textures;
+//         }
+//     }
+//
+//     function checkAll(entries: IterableIterator<{ isFile: boolean, path: string }>) {
+//         for (const entry of entries) {
+//             if (!entry.isFile) {
+//                 continue;
+//             }
+//
+//             check(entry.path);
+//         }
+//     }
+//
+//     checkAll(walkSync("vanilla_mc/models/block"));
+//     checkAll(walkSync("jmx/models/block/v1"));
+// }
+//endregion
+
+//region Create JMX versions of models from args
+{
+    type Identifier = {
+        namespace: string,
+        path: string[],
+    };
+
+    function parseId(id: string): Identifier {
+        const parts = id.split(":");
+        if (parts.length != 2) {
+            return {
+                namespace: "minecraft",
+                path: id.split("/"),
+            };
+        } else {
+            return {
+                namespace: parts[0],
+                path: parts[1].split("/"),
+            };
+        }
+    }
+
+    function idStr(id: Identifier): string {
+        return `${id.namespace}:${id.path.join("/")}`;
+    }
+
+    function modelLocation(id: Identifier): string {
+        return `${id.namespace == "minecraft" ? "vanilla_mc" : id.namespace}/models/${id.path.join("/")}.json`;
+    }
+
+    function toJmx(id: Identifier): Identifier {
+        if (id.namespace == "jmx") {
+            return id;
+        } else {
+            let path = [...id.path];
+            path.splice(1, 0, "v1");
+            if (path[path.length - 1] != "block" && path[path.length - 1] != "thin_block") {
+                path[path.length - 1] = "jmx_" + path[path.length - 1];
+            }
+            return {
+                namespace: "jmx",
+                path,
+            };
+        }
+    }
+
+    function makeParentModels(id: Identifier): [Identifier, JmxModel][] {
+        const path = modelLocation(id);
+        console.log(`visiting ${idStr(id)}`);
+
+        const model = JSON.parse(Deno.readTextFileSync(path)) as Model;
+
+        const parentHasLayers = (() => {
+            if (model.parent) {
+                const parentId = parseId(model.parent);
+                const parentCount = writeParentModels(parentId);
+                const jmxParent = toJmx(parentId);
+                model.parent = idStr(jmxParent);
+                return parentCount > 1;
+            } else {
+                return false;
+            }
+        })();
+
+        const makeWithLayerCount: (layerCount: number) => [Identifier, JmxModel] = (layerCount: number) => {
+            function extractBase(s: string): string {
+                // @ts-ignore
+                return /#?(.*)/.exec(s)[1];
+            }
+
+            const jmxModel = {...model} as JmxModel;
+
+            if (jmxModel.parent) {
+                const parentId = parseId(jmxModel.parent);
+
+                if (parentHasLayers) {
+                    parentId.path.splice(2, 0, layerCount.toString());
+                    jmxModel.parent = idStr(parentId);
+                }
+            }
+
+            if (model.textures) {
+                const textureCount = Object.entries(model.textures).length;
+                // @ts-ignore // only add layers if there's a non-particle texture
+                if (textureCount - !!model.textures.particle) {
+                    function existing<A, B>(x: B | undefined, _default: B): B {
+                        return !!x ? x : _default;
+                    }
+
+                    const existingJmx = existing(jmxModel.jmx, {});
+                    const existingTextures = existing(existingJmx.textures, {});
+                    const existingLayeredTextures = existing(existingTextures.layered_textures, []);
+                    const existingMaterials = existing(existingJmx.materials, []);
+                    const existingTags = existing(existingJmx.tags, []);
+                    const existingColors = existing(existingJmx.colors, []);
+
+                    const layer = (kind: string) =>
+                        Object.fromEntries(
+                            // @ts-ignore
+                            Object.entries(model.textures)
+                                .filter(([key, _]) => key !== "particle")
+                                .map(([key, value]) => {
+                                    const toJmx = (s: string, start: string = "") => {
+                                        const base = extractBase(s);
+                                        return `${start}jmx_${kind}_${base}`;
+                                    }
+                                    return [toJmx(key), toJmx(value, "#")];
+                                })
+                        );
+
+                    const layers = (existing: Layers, base: string): Layers => [...existing].concat(Array(layerCount).fill(layer(base)));
+
+                    jmxModel.jmx = {
+                        ...existingJmx,
+                        // @ts-ignore
+                        textures: {
+                            ...existingTextures,
+                            layered_textures: layers(existingLayeredTextures, "tex"),
+                        },
+                        materials: layers(existingMaterials, "mat"),
+                        tags: layers(existingTags, "tag"),
+                        colors: layers(existingColors, "color"),
+                    }
+                }
+
+                if (model.textures.particle) {
+                    if (!jmxModel.jmx) {
+                        jmxModel.jmx = {};
+                    }
+                    if (!jmxModel.jmx.textures) {
+                        jmxModel.jmx.textures = {};
+                    }
+                    jmxModel.jmx.textures.particle = "#jmx_tex_particle";
+                }
+            }
+
+            if (model.elements) {
+                // @ts-ignore
+                jmxModel.elements = jmxModel.elements.map(element => {
+                    return {
+                        ...element,
+                        faces: Object.fromEntries(Object.entries(element.faces).map(([dir, face]) => {
+                            // @ts-ignore
+                            const base = extractBase(face.texture);
+
+                            // @ts-ignore
+                            const layer = base === "texture"
+                                ? {
+                                    texture: "#jmx_texture",
+                                    material: "#jmx_material",
+                                    tag: "#jmx_tag",
+                                    color: "#jmx_color",
+                                }
+                                : {
+                                    texture: `#jmx_tex_${base}`,
+                                    material: `#jmx_mat_${base}`,
+                                    tag: `#jmx_tag_${base}`,
+                                    color: `#jmx_color_${base}`,
+                                };
+
+                            return [dir, {
+                                ...face,
+                                jmx_layers: Array(layerCount).fill(layer),
+                            }];
+                        })),
+                    };
+                });
+                let jmxId = toJmx(id);
+                jmxId.path.splice(2, 0, layerCount.toString());
+            }
+
+            jmxModel.jmx_version = 1;
+
+            let jmxId = toJmx(id);
+            jmxId.path.splice(2, 0, layerCount.toString());
+            return [jmxId, jmxModel];
+        };
+
+
+        if (model.elements || model.textures) {
+            return [2, 3].map(makeWithLayerCount);
+        } else {
+            const jmxModel = {...model} as JmxModel;
+            jmxModel.jmx_version = 1;
+            return [[toJmx(id), jmxModel]];
+        }
+    }
+
+    function writeParentModels(id: Identifier): number {
+        const parentModels = makeParentModels(id);
+        for (const [modelId, model] of parentModels) {
+            const path = modelLocation(modelId);
+            ensureFileSync(path);
+            Deno.writeTextFileSync(path, JSON.stringify(model, null, 4));
+        }
+        return parentModels.length;
+    }
+
+    const files = [
+        "minecraft:block/crop",
+        "minecraft:block/cross",
+        "minecraft:block/cube",
+        "minecraft:block/cube_all",
+        "minecraft:block/cube_bottom_top",
+        "minecraft:block/cube_column",
+        "minecraft:block/cube_directional",
+        "minecraft:block/cube_mirrored",
+        "minecraft:block/cube_mirrored_all",
+        "minecraft:block/cube_top",
+        "minecraft:block/door_bottom",
+        "minecraft:block/door_bottom_rh",
+        "minecraft:block/door_top",
+        "minecraft:block/door_top_rh",
+        "minecraft:block/fence_inventory",
+        "minecraft:block/fence_post",
+        "minecraft:block/fence_side",
+        "minecraft:block/orientable",
+        "minecraft:block/orientable_vertical",
+        "minecraft:block/orientable_with_bottom",
+        "minecraft:block/slab",
+        "minecraft:block/slab_top",
+        "minecraft:block/stairs",
+        "minecraft:block/stem_fruit",
+        "minecraft:block/stem_growth0",
+        "minecraft:block/stem_growth1",
+        "minecraft:block/stem_growth2",
+        "minecraft:block/stem_growth3",
+        "minecraft:block/stem_growth4",
+        "minecraft:block/stem_growth5",
+        "minecraft:block/stem_growth6",
+        "minecraft:block/stem_growth7",
+        "minecraft:block/template_farmland",
+        "minecraft:block/template_fence_gate",
+        "minecraft:block/template_fence_gate_open",
+        "minecraft:block/template_fence_gate_wall",
+        "minecraft:block/template_fence_gate_wall_open",
+        "minecraft:block/template_glass_pane_noside",
+        "minecraft:block/template_glass_pane_noside_alt",
+        "minecraft:block/template_glass_pane_post",
+        "minecraft:block/template_glass_pane_side",
+        "minecraft:block/template_glass_pane_side_alt",
+        "minecraft:block/template_glazed_terracotta",
+        "minecraft:block/template_orientable_trapdoor_bottom",
+        "minecraft:block/template_orientable_trapdoor_open",
+        "minecraft:block/template_orientable_trapdoor_top",
+        "minecraft:block/template_piston",
+        "minecraft:block/template_piston_head",
+        "minecraft:block/template_piston_head_short",
+        "minecraft:block/template_rail_raised_ne",
+        "minecraft:block/template_rail_raised_sw",
+        "minecraft:block/template_torch",
+        "minecraft:block/template_trapdoor_bottom",
+        "minecraft:block/template_trapdoor_open",
+        "minecraft:block/template_trapdoor_top",
+        "minecraft:block/template_wall_post",
+        "minecraft:block/template_wall_side",
+        "minecraft:block/wall_inventory",
+        "minecraft:block/template_wall_side_tall",
+        "minecraft:block/carpet",
+    ];
+
+    if (existsSync("jmx/models")) {
+        Deno.removeSync("jmx/models", {recursive: true});
+    }
+
+    for (const arg of files) {
+        writeParentModels(parseId(arg));
+    }
+}
+//endregion
+
+//region Diff old and new models
+{
+    const dir = Deno.cwd();
+
+    Deno.chdir("jmx");
+
+    for (const entry of walkSync("models_old")) {
+        if (!entry.isFile) {
+            continue;
+        }
+
+        const oldPath = entry.path;
+        const newPath = entry.path.replaceAll("models_old", "models");
+        if (!existsSync(newPath)) {
+            continue;
+        }
+
+        const oldModel = JSON.parse(Deno.readTextFileSync(oldPath)) as JmxModel;
+        const newModel = JSON.parse(Deno.readTextFileSync(newPath)) as JmxModel;
+
+        // some of the original models are wrong
+        const broken = [
+            "models_old/block/v1/2/jmx_orientable_vertical.json",
+            "models_old/block/v1/3/jmx_orientable_vertical.json",
+            "models_old/block/v1/2/jmx_template_glazed_terracotta.json",
+            "models_old/block/v1/3/jmx_template_glazed_terracotta.json",
+            "models_old/block/v1/2/jmx_cube_bottom_top.json",
+            "models_old/block/v1/3/jmx_cube_bottom_top.json",
+            "models_old/block/v1/2/jmx_orientable_with_bottom.json",
+            "models_old/block/v1/3/jmx_orientable_with_bottom.json",
+            "models_old/block/v1/2/jmx_template_fence_gate_wall.json",
+            "models_old/block/v1/3/jmx_template_fence_gate_wall.json",
+            "models_old/block/v1/2/jmx_template_farmland.json",
+            "models_old/block/v1/3/jmx_template_farmland.json",
+            "models_old/block/v1/2/jmx_cube_top.json",
+            "models_old/block/v1/3/jmx_cube_top.json",
+            "models_old/block/v1/2/jmx_orientable.json",
+            "models_old/block/v1/3/jmx_orientable.json",
+            "models_old/block/v1/2/jmx_stem_fruit.json",
+            "models_old/block/v1/3/jmx_stem_fruit.json",
+            "models_old/block/v1/2/jmx_cube_column.json",
+            "models_old/block/v1/3/jmx_cube_column.json",
+        ];
+        if (broken.includes(entry.path)) {
+            continue;
+        }
+
+        try {
+            assertEquals(oldModel, newModel);
+        } catch (e) {
+            console.log("==== ERROR =====");
+            console.log(`${oldPath} and ${newPath} are different!`);
+            throw e;
+        }
+    }
+
+    Deno.chdir(dir);
+}
+//endregion

--- a/scripts/make_parent_models_v1.ts
+++ b/scripts/make_parent_models_v1.ts
@@ -401,6 +401,10 @@ if (!args.check && !args.create && !args.diff) {
 USAGE:
 Requires Deno (https://deno.land)
 
+CAUTION:
+This script will remove all files in \`src/main/resources/assets/jmx/models\`.
+Use git to restore any non-v1 models.
+
 ARGS:
 --check      checks type definitions against vanilla and JMX models
 --create     creates new parent models based on a variable defined below

--- a/scripts/make_parent_models_v1.ts
+++ b/scripts/make_parent_models_v1.ts
@@ -169,7 +169,17 @@ if (args.create) {
                                 .map(([key, value]) => {
                                     const toJmx = (s: string, start: string = "") => {
                                         const base = extractBase(s);
-                                        return `${start}jmx_${kind}_${base}`;
+
+                                        if (base === "texture") {
+                                            switch (kind) {
+                                                case "tex": return `${start}jmx_texture`;
+                                                case "mat": return `${start}jmx_material`;
+                                                case "tag": return `${start}jmx_tag`;
+                                                case "color": return `${start}jmx_color`;
+                                            }
+                                        } else {
+                                            return `${start}jmx_${kind}_${base}`;
+                                        }
                                     }
                                     return [toJmx(key), toJmx(value, "#")];
                                 })

--- a/scripts/vanilla.ts
+++ b/scripts/vanilla.ts
@@ -1,0 +1,92 @@
+// @ts-ignore
+import {Array, Partial, Record, Tuple, String, Dictionary, Boolean, Number, Union, Literal, Static, Runtype} from "https://raw.githubusercontent.com/alex5nader/runtypes/master/src/index.ts";
+
+export type Vec3 = Static<typeof Vec3>;
+export const Vec3 = Tuple(Number, Number, Number);
+
+export type Transformation = Static<typeof Transformation>;
+export const Transformation = Partial({
+    rotation: Vec3,
+    translation: Vec3,
+    scale: Vec3,
+});
+
+export type ModelTransformation = Static<typeof ModelTransformation>;
+export const ModelTransformation = Partial({
+    thirdperson_righthand: Transformation,
+    thirdperson_lefthand: Transformation,
+    firstperson_righthand: Transformation,
+    firstperson_lefthand: Transformation,
+    gui: Transformation,
+    head: Transformation,
+    ground: Transformation,
+    fixed: Transformation,
+});
+
+export type TextureMap = Static<typeof TextureMap>;
+export const TextureMap = Partial({
+    particle: String,
+}).And(Dictionary(String));
+
+export type Rotation = Static<typeof Rotation>;
+export const Rotation = Record({
+    origin: Vec3,
+    axis: Union(Literal("x"), Literal("y"), Literal("z")),
+    angle: Union(Literal(-45), Literal(-22.5), Literal(0), Literal(22.5), Literal(45)),
+}).And(Partial({
+    rescale: Boolean
+}));
+
+export type Direction = Static<typeof Direction>;
+export const Direction = Union(Literal("down"), Literal("up"), Literal("north"), Literal("south"), Literal("west"), Literal("east"));
+
+export type Face = Static<typeof Face>;
+export const Face = Record({
+    texture: String,
+}).And(Partial({
+    uv: Tuple(Number, Number, Number, Number),
+    cullface: Direction,
+    rotation: Union(Literal(0), Literal(90), Literal(180), Literal(270)),
+    tintindex: Number,
+}));
+
+export function FacesOf<A extends Runtype>(Face: A) {
+    return Partial({
+        down: Face,
+        up: Face,
+        north: Face,
+        south: Face,
+        west: Face,
+        east: Face,
+    });
+}
+
+export type Faces = Static<typeof Faces>;
+export const Faces = FacesOf(Face);
+
+export function ModelElementOf<A extends Runtype>(Faces: A) {
+    return Record({
+        from: Vec3,
+        to: Vec3,
+        faces: Faces
+    }).And(Partial({
+        rotation: Rotation,
+        shade: Boolean,
+    }));
+}
+
+export type ModelElement = Static<typeof ModelElement>;
+export const ModelElement = ModelElementOf(Faces);
+
+export function ModelOf<A extends Runtype>(ModelElement: A) {
+    return Partial({
+        parent: String,
+        ambientocclusion: Boolean,
+        display: ModelTransformation,
+        textures: TextureMap,
+        elements: Array(ModelElement),
+    });
+}
+
+export type Model = Static<typeof Model>;
+export const Model = ModelOf(ModelElement);

--- a/src/main/resources/assets/jmx/models/block/v1/2/jmx_carpet.json
+++ b/src/main/resources/assets/jmx/models/block/v1/2/jmx_carpet.json
@@ -1,0 +1,171 @@
+{
+    "parent": "jmx:block/v1/thin_block",
+    "textures": {
+        "particle": "#wool"
+    },
+    "elements": [
+        {
+            "from": [
+                0,
+                0,
+                0
+            ],
+            "to": [
+                16,
+                1,
+                16
+            ],
+            "faces": {
+                "down": {
+                    "uv": [
+                        0,
+                        0,
+                        16,
+                        16
+                    ],
+                    "texture": "#wool",
+                    "cullface": "down",
+                    "jmx_layers": [
+                        {
+                            "texture": "#jmx_tex_wool",
+                            "material": "#jmx_mat_wool",
+                            "tag": "#jmx_tag_wool",
+                            "color": "#jmx_color_wool"
+                        },
+                        {
+                            "texture": "#jmx_tex_wool",
+                            "material": "#jmx_mat_wool",
+                            "tag": "#jmx_tag_wool",
+                            "color": "#jmx_color_wool"
+                        }
+                    ]
+                },
+                "up": {
+                    "uv": [
+                        0,
+                        0,
+                        16,
+                        16
+                    ],
+                    "texture": "#wool",
+                    "jmx_layers": [
+                        {
+                            "texture": "#jmx_tex_wool",
+                            "material": "#jmx_mat_wool",
+                            "tag": "#jmx_tag_wool",
+                            "color": "#jmx_color_wool"
+                        },
+                        {
+                            "texture": "#jmx_tex_wool",
+                            "material": "#jmx_mat_wool",
+                            "tag": "#jmx_tag_wool",
+                            "color": "#jmx_color_wool"
+                        }
+                    ]
+                },
+                "north": {
+                    "uv": [
+                        0,
+                        15,
+                        16,
+                        16
+                    ],
+                    "texture": "#wool",
+                    "cullface": "north",
+                    "jmx_layers": [
+                        {
+                            "texture": "#jmx_tex_wool",
+                            "material": "#jmx_mat_wool",
+                            "tag": "#jmx_tag_wool",
+                            "color": "#jmx_color_wool"
+                        },
+                        {
+                            "texture": "#jmx_tex_wool",
+                            "material": "#jmx_mat_wool",
+                            "tag": "#jmx_tag_wool",
+                            "color": "#jmx_color_wool"
+                        }
+                    ]
+                },
+                "south": {
+                    "uv": [
+                        0,
+                        15,
+                        16,
+                        16
+                    ],
+                    "texture": "#wool",
+                    "cullface": "south",
+                    "jmx_layers": [
+                        {
+                            "texture": "#jmx_tex_wool",
+                            "material": "#jmx_mat_wool",
+                            "tag": "#jmx_tag_wool",
+                            "color": "#jmx_color_wool"
+                        },
+                        {
+                            "texture": "#jmx_tex_wool",
+                            "material": "#jmx_mat_wool",
+                            "tag": "#jmx_tag_wool",
+                            "color": "#jmx_color_wool"
+                        }
+                    ]
+                },
+                "west": {
+                    "uv": [
+                        0,
+                        15,
+                        16,
+                        16
+                    ],
+                    "texture": "#wool",
+                    "cullface": "west",
+                    "jmx_layers": [
+                        {
+                            "texture": "#jmx_tex_wool",
+                            "material": "#jmx_mat_wool",
+                            "tag": "#jmx_tag_wool",
+                            "color": "#jmx_color_wool"
+                        },
+                        {
+                            "texture": "#jmx_tex_wool",
+                            "material": "#jmx_mat_wool",
+                            "tag": "#jmx_tag_wool",
+                            "color": "#jmx_color_wool"
+                        }
+                    ]
+                },
+                "east": {
+                    "uv": [
+                        0,
+                        15,
+                        16,
+                        16
+                    ],
+                    "texture": "#wool",
+                    "cullface": "east",
+                    "jmx_layers": [
+                        {
+                            "texture": "#jmx_tex_wool",
+                            "material": "#jmx_mat_wool",
+                            "tag": "#jmx_tag_wool",
+                            "color": "#jmx_color_wool"
+                        },
+                        {
+                            "texture": "#jmx_tex_wool",
+                            "material": "#jmx_mat_wool",
+                            "tag": "#jmx_tag_wool",
+                            "color": "#jmx_color_wool"
+                        }
+                    ]
+                }
+            }
+        }
+    ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
+    "jmx_version": 1
+}

--- a/src/main/resources/assets/jmx/models/block/v1/2/jmx_crop.json
+++ b/src/main/resources/assets/jmx/models/block/v1/2/jmx_crop.json
@@ -3,11 +3,6 @@
     "textures": {
         "particle": "#crop"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -254,5 +249,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/2/jmx_cross.json
+++ b/src/main/resources/assets/jmx/models/block/v1/2/jmx_cross.json
@@ -3,11 +3,6 @@
     "textures": {
         "particle": "#cross"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -152,5 +147,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/2/jmx_cube_all.json
+++ b/src/main/resources/assets/jmx/models/block/v1/2/jmx_cube_all.json
@@ -11,7 +11,6 @@
     },
     "jmx": {
         "textures": {
-            "particle": "#jmx_tex_particle",
             "layered_textures": [
                 {
                     "jmx_tex_down": "#jmx_tex_all",
@@ -29,7 +28,8 @@
                     "jmx_tex_south": "#jmx_tex_all",
                     "jmx_tex_west": "#jmx_tex_all"
                 }
-            ]
+            ],
+            "particle": "#jmx_tex_particle"
         },
         "materials": [
             {

--- a/src/main/resources/assets/jmx/models/block/v1/2/jmx_cube_bottom_top.json
+++ b/src/main/resources/assets/jmx/models/block/v1/2/jmx_cube_bottom_top.json
@@ -11,7 +11,6 @@
     },
     "jmx": {
         "textures": {
-            "particle": "#jmx_tex_particle",
             "layered_textures": [
                 {
                     "jmx_tex_down": "#jmx_tex_bottom",
@@ -29,60 +28,61 @@
                     "jmx_tex_south": "#jmx_tex_side",
                     "jmx_tex_west": "#jmx_tex_side"
                 }
-            ]
+            ],
+            "particle": "#jmx_tex_particle"
         },
         "materials": [
             {
-                "jmx_mat_down": "#jmx_mat_all",
-                "jmx_mat_up": "#jmx_mat_all",
-                "jmx_mat_north": "#jmx_mat_all",
-                "jmx_mat_east": "#jmx_mat_all",
-                "jmx_mat_south": "#jmx_mat_all",
-                "jmx_mat_west": "#jmx_mat_all"
+                "jmx_mat_down": "#jmx_mat_bottom",
+                "jmx_mat_up": "#jmx_mat_top",
+                "jmx_mat_north": "#jmx_mat_side",
+                "jmx_mat_east": "#jmx_mat_side",
+                "jmx_mat_south": "#jmx_mat_side",
+                "jmx_mat_west": "#jmx_mat_side"
             },
             {
-                "jmx_mat_down": "#jmx_mat_all",
-                "jmx_mat_up": "#jmx_mat_all",
-                "jmx_mat_north": "#jmx_mat_all",
-                "jmx_mat_east": "#jmx_mat_all",
-                "jmx_mat_south": "#jmx_mat_all",
-                "jmx_mat_west": "#jmx_mat_all"
+                "jmx_mat_down": "#jmx_mat_bottom",
+                "jmx_mat_up": "#jmx_mat_top",
+                "jmx_mat_north": "#jmx_mat_side",
+                "jmx_mat_east": "#jmx_mat_side",
+                "jmx_mat_south": "#jmx_mat_side",
+                "jmx_mat_west": "#jmx_mat_side"
             }
         ],
         "tags": [
             {
-                "jmx_tag_down": "#jmx_tag_all",
-                "jmx_tag_up": "#jmx_tag_all",
-                "jmx_tag_north": "#jmx_tag_all",
-                "jmx_tag_east": "#jmx_tag_all",
-                "jmx_tag_south": "#jmx_tag_all",
-                "jmx_tag_west": "#jmx_tag_all"
+                "jmx_tag_down": "#jmx_tag_bottom",
+                "jmx_tag_up": "#jmx_tag_top",
+                "jmx_tag_north": "#jmx_tag_side",
+                "jmx_tag_east": "#jmx_tag_side",
+                "jmx_tag_south": "#jmx_tag_side",
+                "jmx_tag_west": "#jmx_tag_side"
             },
             {
-                "jmx_tag_down": "#jmx_tag_all",
-                "jmx_tag_up": "#jmx_tag_all",
-                "jmx_tag_north": "#jmx_tag_all",
-                "jmx_tag_east": "#jmx_tag_all",
-                "jmx_tag_south": "#jmx_tag_all",
-                "jmx_tag_west": "#jmx_tag_all"
+                "jmx_tag_down": "#jmx_tag_bottom",
+                "jmx_tag_up": "#jmx_tag_top",
+                "jmx_tag_north": "#jmx_tag_side",
+                "jmx_tag_east": "#jmx_tag_side",
+                "jmx_tag_south": "#jmx_tag_side",
+                "jmx_tag_west": "#jmx_tag_side"
             }
         ],
         "colors": [
             {
-                "jmx_color_down": "#jmx_color_all",
-                "jmx_color_up": "#jmx_color_all",
-                "jmx_color_north": "#jmx_color_all",
-                "jmx_color_east": "#jmx_color_all",
-                "jmx_color_south": "#jmx_color_all",
-                "jmx_color_west": "#jmx_color_all"
+                "jmx_color_down": "#jmx_color_bottom",
+                "jmx_color_up": "#jmx_color_top",
+                "jmx_color_north": "#jmx_color_side",
+                "jmx_color_east": "#jmx_color_side",
+                "jmx_color_south": "#jmx_color_side",
+                "jmx_color_west": "#jmx_color_side"
             },
             {
-                "jmx_color_down": "#jmx_color_all",
-                "jmx_color_up": "#jmx_color_all",
-                "jmx_color_north": "#jmx_color_all",
-                "jmx_color_east": "#jmx_color_all",
-                "jmx_color_south": "#jmx_color_all",
-                "jmx_color_west": "#jmx_color_all"
+                "jmx_color_down": "#jmx_color_bottom",
+                "jmx_color_up": "#jmx_color_top",
+                "jmx_color_north": "#jmx_color_side",
+                "jmx_color_east": "#jmx_color_side",
+                "jmx_color_south": "#jmx_color_side",
+                "jmx_color_west": "#jmx_color_side"
             }
         ]
     },

--- a/src/main/resources/assets/jmx/models/block/v1/2/jmx_cube_column.json
+++ b/src/main/resources/assets/jmx/models/block/v1/2/jmx_cube_column.json
@@ -11,7 +11,6 @@
     },
     "jmx": {
         "textures": {
-            "particle": "#jmx_tex_particle",
             "layered_textures": [
                 {
                     "jmx_tex_down": "#jmx_tex_end",
@@ -29,60 +28,61 @@
                     "jmx_tex_south": "#jmx_tex_side",
                     "jmx_tex_west": "#jmx_tex_side"
                 }
-            ]
+            ],
+            "particle": "#jmx_tex_particle"
         },
         "materials": [
             {
-                "jmx_mat_down": "#jmx_mat_all",
-                "jmx_mat_up": "#jmx_mat_all",
-                "jmx_mat_north": "#jmx_mat_all",
-                "jmx_mat_east": "#jmx_mat_all",
-                "jmx_mat_south": "#jmx_mat_all",
-                "jmx_mat_west": "#jmx_mat_all"
+                "jmx_mat_down": "#jmx_mat_end",
+                "jmx_mat_up": "#jmx_mat_end",
+                "jmx_mat_north": "#jmx_mat_side",
+                "jmx_mat_east": "#jmx_mat_side",
+                "jmx_mat_south": "#jmx_mat_side",
+                "jmx_mat_west": "#jmx_mat_side"
             },
             {
-                "jmx_mat_down": "#jmx_mat_all",
-                "jmx_mat_up": "#jmx_mat_all",
-                "jmx_mat_north": "#jmx_mat_all",
-                "jmx_mat_east": "#jmx_mat_all",
-                "jmx_mat_south": "#jmx_mat_all",
-                "jmx_mat_west": "#jmx_mat_all"
+                "jmx_mat_down": "#jmx_mat_end",
+                "jmx_mat_up": "#jmx_mat_end",
+                "jmx_mat_north": "#jmx_mat_side",
+                "jmx_mat_east": "#jmx_mat_side",
+                "jmx_mat_south": "#jmx_mat_side",
+                "jmx_mat_west": "#jmx_mat_side"
             }
         ],
         "tags": [
             {
-                "jmx_tag_down": "#jmx_tag_all",
-                "jmx_tag_up": "#jmx_tag_all",
-                "jmx_tag_north": "#jmx_tag_all",
-                "jmx_tag_east": "#jmx_tag_all",
-                "jmx_tag_south": "#jmx_tag_all",
-                "jmx_tag_west": "#jmx_tag_all"
+                "jmx_tag_down": "#jmx_tag_end",
+                "jmx_tag_up": "#jmx_tag_end",
+                "jmx_tag_north": "#jmx_tag_side",
+                "jmx_tag_east": "#jmx_tag_side",
+                "jmx_tag_south": "#jmx_tag_side",
+                "jmx_tag_west": "#jmx_tag_side"
             },
             {
-                "jmx_tag_down": "#jmx_tag_all",
-                "jmx_tag_up": "#jmx_tag_all",
-                "jmx_tag_north": "#jmx_tag_all",
-                "jmx_tag_east": "#jmx_tag_all",
-                "jmx_tag_south": "#jmx_tag_all",
-                "jmx_tag_west": "#jmx_tag_all"
+                "jmx_tag_down": "#jmx_tag_end",
+                "jmx_tag_up": "#jmx_tag_end",
+                "jmx_tag_north": "#jmx_tag_side",
+                "jmx_tag_east": "#jmx_tag_side",
+                "jmx_tag_south": "#jmx_tag_side",
+                "jmx_tag_west": "#jmx_tag_side"
             }
         ],
         "colors": [
             {
-                "jmx_color_down": "#jmx_color_all",
-                "jmx_color_up": "#jmx_color_all",
-                "jmx_color_north": "#jmx_color_all",
-                "jmx_color_east": "#jmx_color_all",
-                "jmx_color_south": "#jmx_color_all",
-                "jmx_color_west": "#jmx_color_all"
+                "jmx_color_down": "#jmx_color_end",
+                "jmx_color_up": "#jmx_color_end",
+                "jmx_color_north": "#jmx_color_side",
+                "jmx_color_east": "#jmx_color_side",
+                "jmx_color_south": "#jmx_color_side",
+                "jmx_color_west": "#jmx_color_side"
             },
             {
-                "jmx_color_down": "#jmx_color_all",
-                "jmx_color_up": "#jmx_color_all",
-                "jmx_color_north": "#jmx_color_all",
-                "jmx_color_east": "#jmx_color_all",
-                "jmx_color_south": "#jmx_color_all",
-                "jmx_color_west": "#jmx_color_all"
+                "jmx_color_down": "#jmx_color_end",
+                "jmx_color_up": "#jmx_color_end",
+                "jmx_color_north": "#jmx_color_side",
+                "jmx_color_east": "#jmx_color_side",
+                "jmx_color_south": "#jmx_color_side",
+                "jmx_color_west": "#jmx_color_side"
             }
         ]
     },

--- a/src/main/resources/assets/jmx/models/block/v1/2/jmx_cube_mirrored_all.json
+++ b/src/main/resources/assets/jmx/models/block/v1/2/jmx_cube_mirrored_all.json
@@ -11,7 +11,6 @@
     },
     "jmx": {
         "textures": {
-            "particle": "#jmx_tex_particle",
             "layered_textures": [
                 {
                     "jmx_tex_down": "#jmx_tex_all",
@@ -29,7 +28,8 @@
                     "jmx_tex_south": "#jmx_tex_all",
                     "jmx_tex_west": "#jmx_tex_all"
                 }
-            ]
+            ],
+            "particle": "#jmx_tex_particle"
         },
         "materials": [
             {

--- a/src/main/resources/assets/jmx/models/block/v1/2/jmx_cube_top.json
+++ b/src/main/resources/assets/jmx/models/block/v1/2/jmx_cube_top.json
@@ -11,7 +11,6 @@
     },
     "jmx": {
         "textures": {
-            "particle": "#jmx_tex_particle",
             "layered_textures": [
                 {
                     "jmx_tex_down": "#jmx_tex_side",
@@ -29,60 +28,61 @@
                     "jmx_tex_south": "#jmx_tex_side",
                     "jmx_tex_west": "#jmx_tex_side"
                 }
-            ]
+            ],
+            "particle": "#jmx_tex_particle"
         },
         "materials": [
             {
-                "jmx_mat_down": "#jmx_mat_all",
-                "jmx_mat_up": "#jmx_mat_all",
-                "jmx_mat_north": "#jmx_mat_all",
-                "jmx_mat_east": "#jmx_mat_all",
-                "jmx_mat_south": "#jmx_mat_all",
-                "jmx_mat_west": "#jmx_mat_all"
+                "jmx_mat_down": "#jmx_mat_side",
+                "jmx_mat_up": "#jmx_mat_top",
+                "jmx_mat_north": "#jmx_mat_side",
+                "jmx_mat_east": "#jmx_mat_side",
+                "jmx_mat_south": "#jmx_mat_side",
+                "jmx_mat_west": "#jmx_mat_side"
             },
             {
-                "jmx_mat_down": "#jmx_mat_all",
-                "jmx_mat_up": "#jmx_mat_all",
-                "jmx_mat_north": "#jmx_mat_all",
-                "jmx_mat_east": "#jmx_mat_all",
-                "jmx_mat_south": "#jmx_mat_all",
-                "jmx_mat_west": "#jmx_mat_all"
+                "jmx_mat_down": "#jmx_mat_side",
+                "jmx_mat_up": "#jmx_mat_top",
+                "jmx_mat_north": "#jmx_mat_side",
+                "jmx_mat_east": "#jmx_mat_side",
+                "jmx_mat_south": "#jmx_mat_side",
+                "jmx_mat_west": "#jmx_mat_side"
             }
         ],
         "tags": [
             {
-                "jmx_tag_down": "#jmx_tag_all",
-                "jmx_tag_up": "#jmx_tag_all",
-                "jmx_tag_north": "#jmx_tag_all",
-                "jmx_tag_east": "#jmx_tag_all",
-                "jmx_tag_south": "#jmx_tag_all",
-                "jmx_tag_west": "#jmx_tag_all"
+                "jmx_tag_down": "#jmx_tag_side",
+                "jmx_tag_up": "#jmx_tag_top",
+                "jmx_tag_north": "#jmx_tag_side",
+                "jmx_tag_east": "#jmx_tag_side",
+                "jmx_tag_south": "#jmx_tag_side",
+                "jmx_tag_west": "#jmx_tag_side"
             },
             {
-                "jmx_tag_down": "#jmx_tag_all",
-                "jmx_tag_up": "#jmx_tag_all",
-                "jmx_tag_north": "#jmx_tag_all",
-                "jmx_tag_east": "#jmx_tag_all",
-                "jmx_tag_south": "#jmx_tag_all",
-                "jmx_tag_west": "#jmx_tag_all"
+                "jmx_tag_down": "#jmx_tag_side",
+                "jmx_tag_up": "#jmx_tag_top",
+                "jmx_tag_north": "#jmx_tag_side",
+                "jmx_tag_east": "#jmx_tag_side",
+                "jmx_tag_south": "#jmx_tag_side",
+                "jmx_tag_west": "#jmx_tag_side"
             }
         ],
         "colors": [
             {
-                "jmx_color_down": "#jmx_color_all",
-                "jmx_color_up": "#jmx_color_all",
-                "jmx_color_north": "#jmx_color_all",
-                "jmx_color_east": "#jmx_color_all",
-                "jmx_color_south": "#jmx_color_all",
-                "jmx_color_west": "#jmx_color_all"
+                "jmx_color_down": "#jmx_color_side",
+                "jmx_color_up": "#jmx_color_top",
+                "jmx_color_north": "#jmx_color_side",
+                "jmx_color_east": "#jmx_color_side",
+                "jmx_color_south": "#jmx_color_side",
+                "jmx_color_west": "#jmx_color_side"
             },
             {
-                "jmx_color_down": "#jmx_color_all",
-                "jmx_color_up": "#jmx_color_all",
-                "jmx_color_north": "#jmx_color_all",
-                "jmx_color_east": "#jmx_color_all",
-                "jmx_color_south": "#jmx_color_all",
-                "jmx_color_west": "#jmx_color_all"
+                "jmx_color_down": "#jmx_color_side",
+                "jmx_color_up": "#jmx_color_top",
+                "jmx_color_north": "#jmx_color_side",
+                "jmx_color_east": "#jmx_color_side",
+                "jmx_color_south": "#jmx_color_side",
+                "jmx_color_west": "#jmx_color_side"
             }
         ]
     },

--- a/src/main/resources/assets/jmx/models/block/v1/2/jmx_door_bottom.json
+++ b/src/main/resources/assets/jmx/models/block/v1/2/jmx_door_bottom.json
@@ -3,11 +3,6 @@
     "textures": {
         "particle": "#bottom"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -143,5 +138,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/2/jmx_door_bottom_rh.json
+++ b/src/main/resources/assets/jmx/models/block/v1/2/jmx_door_bottom_rh.json
@@ -3,11 +3,6 @@
     "textures": {
         "particle": "#bottom"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -143,5 +138,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/2/jmx_door_top.json
+++ b/src/main/resources/assets/jmx/models/block/v1/2/jmx_door_top.json
@@ -3,11 +3,6 @@
     "textures": {
         "particle": "#top"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -143,5 +138,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/2/jmx_door_top_rh.json
+++ b/src/main/resources/assets/jmx/models/block/v1/2/jmx_door_top_rh.json
@@ -3,11 +3,6 @@
     "textures": {
         "particle": "#top"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -143,5 +138,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/2/jmx_fence_inventory.json
+++ b/src/main/resources/assets/jmx/models/block/v1/2/jmx_fence_inventory.json
@@ -40,11 +40,6 @@
     "textures": {
         "particle": "#texture"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -661,5 +656,10 @@
             "__comment": "Lower bar"
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/2/jmx_fence_post.json
+++ b/src/main/resources/assets/jmx/models/block/v1/2/jmx_fence_post.json
@@ -2,11 +2,6 @@
     "textures": {
         "particle": "#texture"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -164,5 +159,10 @@
             "__comment": "Center post"
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/2/jmx_fence_side.json
+++ b/src/main/resources/assets/jmx/models/block/v1/2/jmx_fence_side.json
@@ -2,11 +2,6 @@
     "textures": {
         "particle": "#texture"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -271,5 +266,10 @@
             "__comment": "lower bar"
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/2/jmx_orientable.json
+++ b/src/main/resources/assets/jmx/models/block/v1/2/jmx_orientable.json
@@ -16,26 +16,26 @@
         },
         "materials": [
             {
-                "jmx_mat_down": "#jmx_mat_top"
+                "jmx_mat_bottom": "#jmx_mat_top"
             },
             {
-                "jmx_mat_down": "#jmx_mat_top"
+                "jmx_mat_bottom": "#jmx_mat_top"
             }
         ],
         "tags": [
             {
-                "jmx_tag_down": "#jmx_tag_top"
+                "jmx_tag_bottom": "#jmx_tag_top"
             },
             {
-                "jmx_tag_down": "#jmx_tag_top"
+                "jmx_tag_bottom": "#jmx_tag_top"
             }
         ],
         "colors": [
             {
-                "jmx_color_down": "#jmx_color_top"
+                "jmx_color_bottom": "#jmx_color_top"
             },
             {
-                "jmx_color_down": "#jmx_color_top"
+                "jmx_color_bottom": "#jmx_color_top"
             }
         ]
     },

--- a/src/main/resources/assets/jmx/models/block/v1/2/jmx_orientable_vertical.json
+++ b/src/main/resources/assets/jmx/models/block/v1/2/jmx_orientable_vertical.json
@@ -11,7 +11,6 @@
     },
     "jmx": {
         "textures": {
-            "particle": "#jmx_tex_particle",
             "layered_textures": [
                 {
                     "jmx_tex_down": "#jmx_tex_side",
@@ -29,60 +28,61 @@
                     "jmx_tex_south": "#jmx_tex_side",
                     "jmx_tex_west": "#jmx_tex_side"
                 }
-            ]
+            ],
+            "particle": "#jmx_tex_particle"
         },
         "materials": [
             {
-                "jmx_mat_down": "#jmx_mat_all",
+                "jmx_mat_down": "#jmx_mat_side",
                 "jmx_mat_up": "#jmx_mat_front",
-                "jmx_mat_north": "#jmx_mat_all",
-                "jmx_mat_east": "#jmx_mat_all",
-                "jmx_mat_south": "#jmx_mat_all",
-                "jmx_mat_west": "#jmx_mat_all"
+                "jmx_mat_north": "#jmx_mat_side",
+                "jmx_mat_east": "#jmx_mat_side",
+                "jmx_mat_south": "#jmx_mat_side",
+                "jmx_mat_west": "#jmx_mat_side"
             },
             {
-                "jmx_mat_down": "#jmx_mat_all",
+                "jmx_mat_down": "#jmx_mat_side",
                 "jmx_mat_up": "#jmx_mat_front",
-                "jmx_mat_north": "#jmx_mat_all",
-                "jmx_mat_east": "#jmx_mat_all",
-                "jmx_mat_south": "#jmx_mat_all",
-                "jmx_mat_west": "#jmx_mat_all"
+                "jmx_mat_north": "#jmx_mat_side",
+                "jmx_mat_east": "#jmx_mat_side",
+                "jmx_mat_south": "#jmx_mat_side",
+                "jmx_mat_west": "#jmx_mat_side"
             }
         ],
         "tags": [
             {
-                "jmx_tag_down": "#jmx_tag_all",
+                "jmx_tag_down": "#jmx_tag_side",
                 "jmx_tag_up": "#jmx_tag_front",
-                "jmx_tag_north": "#jmx_tag_all",
-                "jmx_tag_east": "#jmx_tag_all",
-                "jmx_tag_south": "#jmx_tag_all",
-                "jmx_tag_west": "#jmx_tag_all"
+                "jmx_tag_north": "#jmx_tag_side",
+                "jmx_tag_east": "#jmx_tag_side",
+                "jmx_tag_south": "#jmx_tag_side",
+                "jmx_tag_west": "#jmx_tag_side"
             },
             {
-                "jmx_tag_down": "#jmx_tag_all",
+                "jmx_tag_down": "#jmx_tag_side",
                 "jmx_tag_up": "#jmx_tag_front",
-                "jmx_tag_north": "#jmx_tag_all",
-                "jmx_tag_east": "#jmx_tag_all",
-                "jmx_tag_south": "#jmx_tag_all",
-                "jmx_tag_west": "#jmx_tag_all"
+                "jmx_tag_north": "#jmx_tag_side",
+                "jmx_tag_east": "#jmx_tag_side",
+                "jmx_tag_south": "#jmx_tag_side",
+                "jmx_tag_west": "#jmx_tag_side"
             }
         ],
         "colors": [
             {
-                "jmx_color_down": "#jmx_color_all",
+                "jmx_color_down": "#jmx_color_side",
                 "jmx_color_up": "#jmx_color_front",
-                "jmx_color_north": "#jmx_color_all",
-                "jmx_color_east": "#jmx_color_all",
-                "jmx_color_south": "#jmx_color_all",
-                "jmx_color_west": "#jmx_color_all"
+                "jmx_color_north": "#jmx_color_side",
+                "jmx_color_east": "#jmx_color_side",
+                "jmx_color_south": "#jmx_color_side",
+                "jmx_color_west": "#jmx_color_side"
             },
             {
-                "jmx_color_down": "#jmx_color_all",
+                "jmx_color_down": "#jmx_color_side",
                 "jmx_color_up": "#jmx_color_front",
-                "jmx_color_north": "#jmx_color_all",
-                "jmx_color_east": "#jmx_color_all",
-                "jmx_color_south": "#jmx_color_all",
-                "jmx_color_west": "#jmx_color_all"
+                "jmx_color_north": "#jmx_color_side",
+                "jmx_color_east": "#jmx_color_side",
+                "jmx_color_south": "#jmx_color_side",
+                "jmx_color_west": "#jmx_color_side"
             }
         ]
     },

--- a/src/main/resources/assets/jmx/models/block/v1/2/jmx_orientable_with_bottom.json
+++ b/src/main/resources/assets/jmx/models/block/v1/2/jmx_orientable_with_bottom.json
@@ -30,7 +30,6 @@
     },
     "jmx": {
         "textures": {
-            "particle": "#jmx_tex_particle",
             "layered_textures": [
                 {
                     "jmx_tex_down": "#jmx_tex_bottom",
@@ -48,24 +47,25 @@
                     "jmx_tex_south": "#jmx_tex_side",
                     "jmx_tex_west": "#jmx_tex_side"
                 }
-            ]
+            ],
+            "particle": "#jmx_tex_particle"
         },
         "materials": [
             {
                 "jmx_mat_down": "#jmx_mat_bottom",
                 "jmx_mat_up": "#jmx_mat_top",
                 "jmx_mat_north": "#jmx_mat_front",
-                "jmx_mat_east": "#jmx_mat_all",
-                "jmx_mat_south": "#jmx_mat_all",
-                "jmx_mat_west": "#jmx_mat_all"
+                "jmx_mat_east": "#jmx_mat_side",
+                "jmx_mat_south": "#jmx_mat_side",
+                "jmx_mat_west": "#jmx_mat_side"
             },
             {
                 "jmx_mat_down": "#jmx_mat_bottom",
                 "jmx_mat_up": "#jmx_mat_top",
                 "jmx_mat_north": "#jmx_mat_front",
-                "jmx_mat_east": "#jmx_mat_all",
-                "jmx_mat_south": "#jmx_mat_all",
-                "jmx_mat_west": "#jmx_mat_all"
+                "jmx_mat_east": "#jmx_mat_side",
+                "jmx_mat_south": "#jmx_mat_side",
+                "jmx_mat_west": "#jmx_mat_side"
             }
         ],
         "tags": [
@@ -73,17 +73,17 @@
                 "jmx_tag_down": "#jmx_tag_bottom",
                 "jmx_tag_up": "#jmx_tag_top",
                 "jmx_tag_north": "#jmx_tag_front",
-                "jmx_tag_east": "#jmx_tag_all",
-                "jmx_tag_south": "#jmx_tag_all",
-                "jmx_tag_west": "#jmx_tag_all"
+                "jmx_tag_east": "#jmx_tag_side",
+                "jmx_tag_south": "#jmx_tag_side",
+                "jmx_tag_west": "#jmx_tag_side"
             },
             {
                 "jmx_tag_down": "#jmx_tag_bottom",
                 "jmx_tag_up": "#jmx_tag_top",
                 "jmx_tag_north": "#jmx_tag_front",
-                "jmx_tag_east": "#jmx_tag_all",
-                "jmx_tag_south": "#jmx_tag_all",
-                "jmx_tag_west": "#jmx_tag_all"
+                "jmx_tag_east": "#jmx_tag_side",
+                "jmx_tag_south": "#jmx_tag_side",
+                "jmx_tag_west": "#jmx_tag_side"
             }
         ],
         "colors": [
@@ -91,17 +91,17 @@
                 "jmx_color_down": "#jmx_color_bottom",
                 "jmx_color_up": "#jmx_color_top",
                 "jmx_color_north": "#jmx_color_front",
-                "jmx_color_east": "#jmx_color_all",
-                "jmx_color_south": "#jmx_color_all",
-                "jmx_color_west": "#jmx_color_all"
+                "jmx_color_east": "#jmx_color_side",
+                "jmx_color_south": "#jmx_color_side",
+                "jmx_color_west": "#jmx_color_side"
             },
             {
                 "jmx_color_down": "#jmx_color_bottom",
                 "jmx_color_up": "#jmx_color_top",
                 "jmx_color_north": "#jmx_color_front",
-                "jmx_color_east": "#jmx_color_all",
-                "jmx_color_south": "#jmx_color_all",
-                "jmx_color_west": "#jmx_color_all"
+                "jmx_color_east": "#jmx_color_side",
+                "jmx_color_south": "#jmx_color_side",
+                "jmx_color_west": "#jmx_color_side"
             }
         ]
     },

--- a/src/main/resources/assets/jmx/models/block/v1/2/jmx_slab.json
+++ b/src/main/resources/assets/jmx/models/block/v1/2/jmx_slab.json
@@ -3,11 +3,6 @@
     "textures": {
         "particle": "#side"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -167,5 +162,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/2/jmx_slab_top.json
+++ b/src/main/resources/assets/jmx/models/block/v1/2/jmx_slab_top.json
@@ -2,11 +2,6 @@
     "textures": {
         "particle": "#side"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -166,5 +161,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/2/jmx_stairs.json
+++ b/src/main/resources/assets/jmx/models/block/v1/2/jmx_stairs.json
@@ -56,11 +56,6 @@
     "textures": {
         "particle": "#side"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -353,5 +348,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/2/jmx_stem_fruit.json
+++ b/src/main/resources/assets/jmx/models/block/v1/2/jmx_stem_fruit.json
@@ -3,11 +3,6 @@
     "textures": {
         "particle": "#stem"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -176,16 +171,16 @@
                     "tintindex": 0,
                     "jmx_layers": [
                         {
-                            "texture": "#jmx_tex_stem",
-                            "material": "#jmx_mat_stem",
-                            "tag": "#jmx_tag_stem",
-                            "color": "#jmx_color_stem"
+                            "texture": "#jmx_tex_upperstem",
+                            "material": "#jmx_mat_upperstem",
+                            "tag": "#jmx_tag_upperstem",
+                            "color": "#jmx_color_upperstem"
                         },
                         {
-                            "texture": "#jmx_tex_stem",
-                            "material": "#jmx_mat_stem",
-                            "tag": "#jmx_tag_stem",
-                            "color": "#jmx_color_stem"
+                            "texture": "#jmx_tex_upperstem",
+                            "material": "#jmx_mat_upperstem",
+                            "tag": "#jmx_tag_upperstem",
+                            "color": "#jmx_color_upperstem"
                         }
                     ]
                 },
@@ -200,21 +195,26 @@
                     "tintindex": 0,
                     "jmx_layers": [
                         {
-                            "texture": "#jmx_tex_stem",
-                            "material": "#jmx_mat_stem",
-                            "tag": "#jmx_tag_stem",
-                            "color": "#jmx_color_stem"
+                            "texture": "#jmx_tex_upperstem",
+                            "material": "#jmx_mat_upperstem",
+                            "tag": "#jmx_tag_upperstem",
+                            "color": "#jmx_color_upperstem"
                         },
                         {
-                            "texture": "#jmx_tex_stem",
-                            "material": "#jmx_mat_stem",
-                            "tag": "#jmx_tag_stem",
-                            "color": "#jmx_color_stem"
+                            "texture": "#jmx_tex_upperstem",
+                            "material": "#jmx_mat_upperstem",
+                            "tag": "#jmx_tag_upperstem",
+                            "color": "#jmx_color_upperstem"
                         }
                     ]
                 }
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/2/jmx_stem_growth0.json
+++ b/src/main/resources/assets/jmx/models/block/v1/2/jmx_stem_growth0.json
@@ -3,11 +3,6 @@
     "textures": {
         "particle": "#stem"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -154,5 +149,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/2/jmx_stem_growth1.json
+++ b/src/main/resources/assets/jmx/models/block/v1/2/jmx_stem_growth1.json
@@ -3,11 +3,6 @@
     "textures": {
         "particle": "#stem"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -154,5 +149,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/2/jmx_stem_growth2.json
+++ b/src/main/resources/assets/jmx/models/block/v1/2/jmx_stem_growth2.json
@@ -3,11 +3,6 @@
     "textures": {
         "particle": "#stem"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -154,5 +149,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/2/jmx_stem_growth3.json
+++ b/src/main/resources/assets/jmx/models/block/v1/2/jmx_stem_growth3.json
@@ -3,11 +3,6 @@
     "textures": {
         "particle": "#stem"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -154,5 +149,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/2/jmx_stem_growth4.json
+++ b/src/main/resources/assets/jmx/models/block/v1/2/jmx_stem_growth4.json
@@ -3,11 +3,6 @@
     "textures": {
         "particle": "#stem"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -154,5 +149,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/2/jmx_stem_growth5.json
+++ b/src/main/resources/assets/jmx/models/block/v1/2/jmx_stem_growth5.json
@@ -3,11 +3,6 @@
     "textures": {
         "particle": "#stem"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -154,5 +149,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/2/jmx_stem_growth6.json
+++ b/src/main/resources/assets/jmx/models/block/v1/2/jmx_stem_growth6.json
@@ -3,11 +3,6 @@
     "textures": {
         "particle": "#stem"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -154,5 +149,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/2/jmx_stem_growth7.json
+++ b/src/main/resources/assets/jmx/models/block/v1/2/jmx_stem_growth7.json
@@ -3,11 +3,6 @@
     "textures": {
         "particle": "#stem"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -154,5 +149,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/2/jmx_template_farmland.json
+++ b/src/main/resources/assets/jmx/models/block/v1/2/jmx_template_farmland.json
@@ -1,5 +1,8 @@
 {
     "parent": "jmx:block/v1/block",
+    "textures": {
+        "particle": "#dirt"
+    },
     "elements": [
         {
             "from": [
@@ -159,5 +162,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/2/jmx_template_fence_gate.json
+++ b/src/main/resources/assets/jmx/models/block/v1/2/jmx_template_fence_gate.json
@@ -39,11 +39,6 @@
     "textures": {
         "particle": "#texture"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "__comment": "Left-hand post",
@@ -1088,5 +1083,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/2/jmx_template_fence_gate_open.json
+++ b/src/main/resources/assets/jmx/models/block/v1/2/jmx_template_fence_gate_open.json
@@ -2,11 +2,6 @@
     "textures": {
         "particle": "#texture"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "__comment": "Left-hand post",
@@ -1051,5 +1046,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/2/jmx_template_fence_gate_wall.json
+++ b/src/main/resources/assets/jmx/models/block/v1/2/jmx_template_fence_gate_wall.json
@@ -3,11 +3,6 @@
     "textures": {
         "particle": "#texture"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "__comment": "Left-hand post",
@@ -750,7 +745,21 @@
                         6,
                         9
                     ],
-                    "texture": "#texture"
+                    "texture": "#texture",
+                    "jmx_layers": [
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        },
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        }
+                    ]
                 },
                 "up": {
                     "uv": [
@@ -759,7 +768,21 @@
                         6,
                         9
                     ],
-                    "texture": "#texture"
+                    "texture": "#texture",
+                    "jmx_layers": [
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        },
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        }
+                    ]
                 },
                 "north": {
                     "uv": [
@@ -768,7 +791,21 @@
                         6,
                         4
                     ],
-                    "texture": "#texture"
+                    "texture": "#texture",
+                    "jmx_layers": [
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        },
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        }
+                    ]
                 },
                 "south": {
                     "uv": [
@@ -777,7 +814,21 @@
                         6,
                         4
                     ],
-                    "texture": "#texture"
+                    "texture": "#texture",
+                    "jmx_layers": [
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        },
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        }
+                    ]
                 }
             }
         },
@@ -801,7 +852,21 @@
                         14,
                         9
                     ],
-                    "texture": "#texture"
+                    "texture": "#texture",
+                    "jmx_layers": [
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        },
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        }
+                    ]
                 },
                 "up": {
                     "uv": [
@@ -810,7 +875,21 @@
                         14,
                         9
                     ],
-                    "texture": "#texture"
+                    "texture": "#texture",
+                    "jmx_layers": [
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        },
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        }
+                    ]
                 },
                 "north": {
                     "uv": [
@@ -819,7 +898,21 @@
                         14,
                         10
                     ],
-                    "texture": "#texture"
+                    "texture": "#texture",
+                    "jmx_layers": [
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        },
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        }
+                    ]
                 },
                 "south": {
                     "uv": [
@@ -828,7 +921,21 @@
                         14,
                         10
                     ],
-                    "texture": "#texture"
+                    "texture": "#texture",
+                    "jmx_layers": [
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        },
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        }
+                    ]
                 }
             }
         },
@@ -852,7 +959,21 @@
                         14,
                         9
                     ],
-                    "texture": "#texture"
+                    "texture": "#texture",
+                    "jmx_layers": [
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        },
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        }
+                    ]
                 },
                 "up": {
                     "uv": [
@@ -861,7 +982,21 @@
                         14,
                         9
                     ],
-                    "texture": "#texture"
+                    "texture": "#texture",
+                    "jmx_layers": [
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        },
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        }
+                    ]
                 },
                 "north": {
                     "uv": [
@@ -870,7 +1005,21 @@
                         14,
                         4
                     ],
-                    "texture": "#texture"
+                    "texture": "#texture",
+                    "jmx_layers": [
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        },
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        }
+                    ]
                 },
                 "south": {
                     "uv": [
@@ -879,10 +1028,29 @@
                         14,
                         4
                     ],
-                    "texture": "#texture"
+                    "texture": "#texture",
+                    "jmx_layers": [
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        },
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        }
+                    ]
                 }
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/2/jmx_template_fence_gate_wall_open.json
+++ b/src/main/resources/assets/jmx/models/block/v1/2/jmx_template_fence_gate_wall_open.json
@@ -3,11 +3,6 @@
     "textures": {
         "particle": "#texture"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "__comment": "Left-hand post",
@@ -1052,5 +1047,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/2/jmx_template_glass_pane_noside.json
+++ b/src/main/resources/assets/jmx/models/block/v1/2/jmx_template_glass_pane_noside.json
@@ -3,11 +3,6 @@
     "textures": {
         "particle": "#pane"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -47,5 +42,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/2/jmx_template_glass_pane_noside_alt.json
+++ b/src/main/resources/assets/jmx/models/block/v1/2/jmx_template_glass_pane_noside_alt.json
@@ -3,11 +3,6 @@
     "textures": {
         "particle": "#pane"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -47,5 +42,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/2/jmx_template_glass_pane_post.json
+++ b/src/main/resources/assets/jmx/models/block/v1/2/jmx_template_glass_pane_post.json
@@ -3,11 +3,6 @@
     "textures": {
         "particle": "#pane"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -70,5 +65,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/2/jmx_template_glass_pane_side.json
+++ b/src/main/resources/assets/jmx/models/block/v1/2/jmx_template_glass_pane_side.json
@@ -3,11 +3,6 @@
     "textures": {
         "particle": "#pane"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -140,5 +135,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/2/jmx_template_glass_pane_side_alt.json
+++ b/src/main/resources/assets/jmx/models/block/v1/2/jmx_template_glass_pane_side_alt.json
@@ -3,11 +3,6 @@
     "textures": {
         "particle": "#pane"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -140,5 +135,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/2/jmx_template_glazed_terracotta.json
+++ b/src/main/resources/assets/jmx/models/block/v1/2/jmx_template_glazed_terracotta.json
@@ -1,5 +1,8 @@
 {
     "parent": "jmx:block/v1/2/jmx_cube",
+    "textures": {
+        "particle": "#pattern"
+    },
     "display": {
         "firstperson_righthand": {
             "rotation": [
@@ -183,5 +186,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/2/jmx_template_orientable_trapdoor_bottom.json
+++ b/src/main/resources/assets/jmx/models/block/v1/2/jmx_template_orientable_trapdoor_bottom.json
@@ -3,11 +3,6 @@
     "textures": {
         "particle": "#texture"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -167,5 +162,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/2/jmx_template_orientable_trapdoor_open.json
+++ b/src/main/resources/assets/jmx/models/block/v1/2/jmx_template_orientable_trapdoor_open.json
@@ -2,11 +2,6 @@
     "textures": {
         "particle": "#texture"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -168,5 +163,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/2/jmx_template_orientable_trapdoor_top.json
+++ b/src/main/resources/assets/jmx/models/block/v1/2/jmx_template_orientable_trapdoor_top.json
@@ -2,11 +2,6 @@
     "textures": {
         "particle": "#texture"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -166,5 +161,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/2/jmx_template_piston.json
+++ b/src/main/resources/assets/jmx/models/block/v1/2/jmx_template_piston.json
@@ -2,11 +2,6 @@
     "textures": {
         "particle": "#side"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -170,5 +165,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/2/jmx_template_piston_head.json
+++ b/src/main/resources/assets/jmx/models/block/v1/2/jmx_template_piston_head.json
@@ -2,11 +2,6 @@
     "textures": {
         "particle": "#platform"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -277,5 +272,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/2/jmx_template_piston_head_short.json
+++ b/src/main/resources/assets/jmx/models/block/v1/2/jmx_template_piston_head_short.json
@@ -2,11 +2,6 @@
     "textures": {
         "particle": "#platform"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -277,5 +272,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/2/jmx_template_rail_raised_ne.json
+++ b/src/main/resources/assets/jmx/models/block/v1/2/jmx_template_rail_raised_ne.json
@@ -3,11 +3,6 @@
     "textures": {
         "particle": "#rail"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -80,5 +75,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/2/jmx_template_rail_raised_sw.json
+++ b/src/main/resources/assets/jmx/models/block/v1/2/jmx_template_rail_raised_sw.json
@@ -3,11 +3,6 @@
     "textures": {
         "particle": "#rail"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -80,5 +75,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/2/jmx_template_torch.json
+++ b/src/main/resources/assets/jmx/models/block/v1/2/jmx_template_torch.json
@@ -3,11 +3,6 @@
     "textures": {
         "particle": "#torch"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -193,5 +188,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/2/jmx_template_trapdoor_bottom.json
+++ b/src/main/resources/assets/jmx/models/block/v1/2/jmx_template_trapdoor_bottom.json
@@ -3,11 +3,6 @@
     "textures": {
         "particle": "#texture"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -167,5 +162,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/2/jmx_template_trapdoor_open.json
+++ b/src/main/resources/assets/jmx/models/block/v1/2/jmx_template_trapdoor_open.json
@@ -2,11 +2,6 @@
     "textures": {
         "particle": "#texture"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -166,5 +161,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/2/jmx_template_trapdoor_top.json
+++ b/src/main/resources/assets/jmx/models/block/v1/2/jmx_template_trapdoor_top.json
@@ -2,11 +2,6 @@
     "textures": {
         "particle": "#texture"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -166,5 +161,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/2/jmx_template_wall_post.json
+++ b/src/main/resources/assets/jmx/models/block/v1/2/jmx_template_wall_post.json
@@ -2,11 +2,6 @@
     "textures": {
         "particle": "#wall"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -128,5 +123,10 @@
             "__comment": "Center post"
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/2/jmx_template_wall_side_tall.json
+++ b/src/main/resources/assets/jmx/models/block/v1/2/jmx_template_wall_side_tall.json
@@ -11,7 +11,7 @@
             ],
             "to": [
                 11,
-                14,
+                16,
                 8
             ],
             "faces": {
@@ -35,6 +35,7 @@
                 },
                 "up": {
                     "texture": "#wall",
+                    "cullface": "up",
                     "jmx_layers": [
                         {
                             "texture": "#jmx_tex_wall",
@@ -102,8 +103,7 @@
                         }
                     ]
                 }
-            },
-            "__comment": "wall"
+            }
         }
     ],
     "jmx": {

--- a/src/main/resources/assets/jmx/models/block/v1/2/jmx_wall_inventory.json
+++ b/src/main/resources/assets/jmx/models/block/v1/2/jmx_wall_inventory.json
@@ -1,4 +1,42 @@
 {
+    "parent": "jmx:block/v1/block",
+    "display": {
+        "gui": {
+            "rotation": [
+                30,
+                135,
+                0
+            ],
+            "translation": [
+                0,
+                0,
+                0
+            ],
+            "scale": [
+                0.625,
+                0.625,
+                0.625
+            ]
+        },
+        "fixed": {
+            "rotation": [
+                0,
+                90,
+                0
+            ],
+            "translation": [
+                0,
+                0,
+                0
+            ],
+            "scale": [
+                0.5,
+                0.5,
+                0.5
+            ]
+        }
+    },
+    "ambientocclusion": false,
     "textures": {
         "particle": "#wall"
     },
@@ -16,15 +54,15 @@
             ],
             "faces": {
                 "down": {
+                    "uv": [
+                        4,
+                        4,
+                        12,
+                        12
+                    ],
                     "texture": "#wall",
                     "cullface": "down",
                     "jmx_layers": [
-                        {
-                            "texture": "#jmx_tex_wall",
-                            "material": "#jmx_mat_wall",
-                            "tag": "#jmx_tag_wall",
-                            "color": "#jmx_color_wall"
-                        },
                         {
                             "texture": "#jmx_tex_wall",
                             "material": "#jmx_mat_wall",
@@ -40,15 +78,14 @@
                     ]
                 },
                 "up": {
+                    "uv": [
+                        4,
+                        4,
+                        12,
+                        12
+                    ],
                     "texture": "#wall",
-                    "cullface": "up",
                     "jmx_layers": [
-                        {
-                            "texture": "#jmx_tex_wall",
-                            "material": "#jmx_mat_wall",
-                            "tag": "#jmx_tag_wall",
-                            "color": "#jmx_color_wall"
-                        },
                         {
                             "texture": "#jmx_tex_wall",
                             "material": "#jmx_mat_wall",
@@ -64,14 +101,14 @@
                     ]
                 },
                 "north": {
+                    "uv": [
+                        4,
+                        0,
+                        12,
+                        16
+                    ],
                     "texture": "#wall",
                     "jmx_layers": [
-                        {
-                            "texture": "#jmx_tex_wall",
-                            "material": "#jmx_mat_wall",
-                            "tag": "#jmx_tag_wall",
-                            "color": "#jmx_color_wall"
-                        },
                         {
                             "texture": "#jmx_tex_wall",
                             "material": "#jmx_mat_wall",
@@ -87,14 +124,14 @@
                     ]
                 },
                 "south": {
+                    "uv": [
+                        4,
+                        0,
+                        12,
+                        16
+                    ],
                     "texture": "#wall",
                     "jmx_layers": [
-                        {
-                            "texture": "#jmx_tex_wall",
-                            "material": "#jmx_mat_wall",
-                            "tag": "#jmx_tag_wall",
-                            "color": "#jmx_color_wall"
-                        },
                         {
                             "texture": "#jmx_tex_wall",
                             "material": "#jmx_mat_wall",
@@ -110,14 +147,14 @@
                     ]
                 },
                 "west": {
+                    "uv": [
+                        4,
+                        0,
+                        12,
+                        16
+                    ],
                     "texture": "#wall",
                     "jmx_layers": [
-                        {
-                            "texture": "#jmx_tex_wall",
-                            "material": "#jmx_mat_wall",
-                            "tag": "#jmx_tag_wall",
-                            "color": "#jmx_color_wall"
-                        },
                         {
                             "texture": "#jmx_tex_wall",
                             "material": "#jmx_mat_wall",
@@ -133,14 +170,14 @@
                     ]
                 },
                 "east": {
+                    "uv": [
+                        4,
+                        0,
+                        12,
+                        16
+                    ],
                     "texture": "#wall",
                     "jmx_layers": [
-                        {
-                            "texture": "#jmx_tex_wall",
-                            "material": "#jmx_mat_wall",
-                            "tag": "#jmx_tag_wall",
-                            "color": "#jmx_color_wall"
-                        },
                         {
                             "texture": "#jmx_tex_wall",
                             "material": "#jmx_mat_wall",
@@ -157,6 +194,162 @@
                 }
             },
             "__comment": "Center post"
+        },
+        {
+            "from": [
+                5,
+                0,
+                0
+            ],
+            "to": [
+                11,
+                13,
+                16
+            ],
+            "faces": {
+                "down": {
+                    "uv": [
+                        5,
+                        0,
+                        11,
+                        16
+                    ],
+                    "texture": "#wall",
+                    "cullface": "down",
+                    "jmx_layers": [
+                        {
+                            "texture": "#jmx_tex_wall",
+                            "material": "#jmx_mat_wall",
+                            "tag": "#jmx_tag_wall",
+                            "color": "#jmx_color_wall"
+                        },
+                        {
+                            "texture": "#jmx_tex_wall",
+                            "material": "#jmx_mat_wall",
+                            "tag": "#jmx_tag_wall",
+                            "color": "#jmx_color_wall"
+                        }
+                    ]
+                },
+                "up": {
+                    "uv": [
+                        5,
+                        0,
+                        11,
+                        16
+                    ],
+                    "texture": "#wall",
+                    "jmx_layers": [
+                        {
+                            "texture": "#jmx_tex_wall",
+                            "material": "#jmx_mat_wall",
+                            "tag": "#jmx_tag_wall",
+                            "color": "#jmx_color_wall"
+                        },
+                        {
+                            "texture": "#jmx_tex_wall",
+                            "material": "#jmx_mat_wall",
+                            "tag": "#jmx_tag_wall",
+                            "color": "#jmx_color_wall"
+                        }
+                    ]
+                },
+                "north": {
+                    "uv": [
+                        5,
+                        3,
+                        11,
+                        16
+                    ],
+                    "texture": "#wall",
+                    "cullface": "north",
+                    "jmx_layers": [
+                        {
+                            "texture": "#jmx_tex_wall",
+                            "material": "#jmx_mat_wall",
+                            "tag": "#jmx_tag_wall",
+                            "color": "#jmx_color_wall"
+                        },
+                        {
+                            "texture": "#jmx_tex_wall",
+                            "material": "#jmx_mat_wall",
+                            "tag": "#jmx_tag_wall",
+                            "color": "#jmx_color_wall"
+                        }
+                    ]
+                },
+                "south": {
+                    "uv": [
+                        5,
+                        3,
+                        11,
+                        16
+                    ],
+                    "texture": "#wall",
+                    "cullface": "south",
+                    "jmx_layers": [
+                        {
+                            "texture": "#jmx_tex_wall",
+                            "material": "#jmx_mat_wall",
+                            "tag": "#jmx_tag_wall",
+                            "color": "#jmx_color_wall"
+                        },
+                        {
+                            "texture": "#jmx_tex_wall",
+                            "material": "#jmx_mat_wall",
+                            "tag": "#jmx_tag_wall",
+                            "color": "#jmx_color_wall"
+                        }
+                    ]
+                },
+                "west": {
+                    "uv": [
+                        0,
+                        3,
+                        16,
+                        16
+                    ],
+                    "texture": "#wall",
+                    "jmx_layers": [
+                        {
+                            "texture": "#jmx_tex_wall",
+                            "material": "#jmx_mat_wall",
+                            "tag": "#jmx_tag_wall",
+                            "color": "#jmx_color_wall"
+                        },
+                        {
+                            "texture": "#jmx_tex_wall",
+                            "material": "#jmx_mat_wall",
+                            "tag": "#jmx_tag_wall",
+                            "color": "#jmx_color_wall"
+                        }
+                    ]
+                },
+                "east": {
+                    "uv": [
+                        0,
+                        3,
+                        16,
+                        16
+                    ],
+                    "texture": "#wall",
+                    "jmx_layers": [
+                        {
+                            "texture": "#jmx_tex_wall",
+                            "material": "#jmx_mat_wall",
+                            "tag": "#jmx_tag_wall",
+                            "color": "#jmx_color_wall"
+                        },
+                        {
+                            "texture": "#jmx_tex_wall",
+                            "material": "#jmx_mat_wall",
+                            "tag": "#jmx_tag_wall",
+                            "color": "#jmx_color_wall"
+                        }
+                    ]
+                }
+            },
+            "__comment": "Full wall"
         }
     ],
     "jmx": {

--- a/src/main/resources/assets/jmx/models/block/v1/3/jmx_carpet.json
+++ b/src/main/resources/assets/jmx/models/block/v1/3/jmx_carpet.json
@@ -1,0 +1,207 @@
+{
+    "parent": "jmx:block/v1/thin_block",
+    "textures": {
+        "particle": "#wool"
+    },
+    "elements": [
+        {
+            "from": [
+                0,
+                0,
+                0
+            ],
+            "to": [
+                16,
+                1,
+                16
+            ],
+            "faces": {
+                "down": {
+                    "uv": [
+                        0,
+                        0,
+                        16,
+                        16
+                    ],
+                    "texture": "#wool",
+                    "cullface": "down",
+                    "jmx_layers": [
+                        {
+                            "texture": "#jmx_tex_wool",
+                            "material": "#jmx_mat_wool",
+                            "tag": "#jmx_tag_wool",
+                            "color": "#jmx_color_wool"
+                        },
+                        {
+                            "texture": "#jmx_tex_wool",
+                            "material": "#jmx_mat_wool",
+                            "tag": "#jmx_tag_wool",
+                            "color": "#jmx_color_wool"
+                        },
+                        {
+                            "texture": "#jmx_tex_wool",
+                            "material": "#jmx_mat_wool",
+                            "tag": "#jmx_tag_wool",
+                            "color": "#jmx_color_wool"
+                        }
+                    ]
+                },
+                "up": {
+                    "uv": [
+                        0,
+                        0,
+                        16,
+                        16
+                    ],
+                    "texture": "#wool",
+                    "jmx_layers": [
+                        {
+                            "texture": "#jmx_tex_wool",
+                            "material": "#jmx_mat_wool",
+                            "tag": "#jmx_tag_wool",
+                            "color": "#jmx_color_wool"
+                        },
+                        {
+                            "texture": "#jmx_tex_wool",
+                            "material": "#jmx_mat_wool",
+                            "tag": "#jmx_tag_wool",
+                            "color": "#jmx_color_wool"
+                        },
+                        {
+                            "texture": "#jmx_tex_wool",
+                            "material": "#jmx_mat_wool",
+                            "tag": "#jmx_tag_wool",
+                            "color": "#jmx_color_wool"
+                        }
+                    ]
+                },
+                "north": {
+                    "uv": [
+                        0,
+                        15,
+                        16,
+                        16
+                    ],
+                    "texture": "#wool",
+                    "cullface": "north",
+                    "jmx_layers": [
+                        {
+                            "texture": "#jmx_tex_wool",
+                            "material": "#jmx_mat_wool",
+                            "tag": "#jmx_tag_wool",
+                            "color": "#jmx_color_wool"
+                        },
+                        {
+                            "texture": "#jmx_tex_wool",
+                            "material": "#jmx_mat_wool",
+                            "tag": "#jmx_tag_wool",
+                            "color": "#jmx_color_wool"
+                        },
+                        {
+                            "texture": "#jmx_tex_wool",
+                            "material": "#jmx_mat_wool",
+                            "tag": "#jmx_tag_wool",
+                            "color": "#jmx_color_wool"
+                        }
+                    ]
+                },
+                "south": {
+                    "uv": [
+                        0,
+                        15,
+                        16,
+                        16
+                    ],
+                    "texture": "#wool",
+                    "cullface": "south",
+                    "jmx_layers": [
+                        {
+                            "texture": "#jmx_tex_wool",
+                            "material": "#jmx_mat_wool",
+                            "tag": "#jmx_tag_wool",
+                            "color": "#jmx_color_wool"
+                        },
+                        {
+                            "texture": "#jmx_tex_wool",
+                            "material": "#jmx_mat_wool",
+                            "tag": "#jmx_tag_wool",
+                            "color": "#jmx_color_wool"
+                        },
+                        {
+                            "texture": "#jmx_tex_wool",
+                            "material": "#jmx_mat_wool",
+                            "tag": "#jmx_tag_wool",
+                            "color": "#jmx_color_wool"
+                        }
+                    ]
+                },
+                "west": {
+                    "uv": [
+                        0,
+                        15,
+                        16,
+                        16
+                    ],
+                    "texture": "#wool",
+                    "cullface": "west",
+                    "jmx_layers": [
+                        {
+                            "texture": "#jmx_tex_wool",
+                            "material": "#jmx_mat_wool",
+                            "tag": "#jmx_tag_wool",
+                            "color": "#jmx_color_wool"
+                        },
+                        {
+                            "texture": "#jmx_tex_wool",
+                            "material": "#jmx_mat_wool",
+                            "tag": "#jmx_tag_wool",
+                            "color": "#jmx_color_wool"
+                        },
+                        {
+                            "texture": "#jmx_tex_wool",
+                            "material": "#jmx_mat_wool",
+                            "tag": "#jmx_tag_wool",
+                            "color": "#jmx_color_wool"
+                        }
+                    ]
+                },
+                "east": {
+                    "uv": [
+                        0,
+                        15,
+                        16,
+                        16
+                    ],
+                    "texture": "#wool",
+                    "cullface": "east",
+                    "jmx_layers": [
+                        {
+                            "texture": "#jmx_tex_wool",
+                            "material": "#jmx_mat_wool",
+                            "tag": "#jmx_tag_wool",
+                            "color": "#jmx_color_wool"
+                        },
+                        {
+                            "texture": "#jmx_tex_wool",
+                            "material": "#jmx_mat_wool",
+                            "tag": "#jmx_tag_wool",
+                            "color": "#jmx_color_wool"
+                        },
+                        {
+                            "texture": "#jmx_tex_wool",
+                            "material": "#jmx_mat_wool",
+                            "tag": "#jmx_tag_wool",
+                            "color": "#jmx_color_wool"
+                        }
+                    ]
+                }
+            }
+        }
+    ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
+    "jmx_version": 1
+}

--- a/src/main/resources/assets/jmx/models/block/v1/3/jmx_crop.json
+++ b/src/main/resources/assets/jmx/models/block/v1/3/jmx_crop.json
@@ -3,11 +3,6 @@
     "textures": {
         "particle": "#crop"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -302,5 +297,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/3/jmx_cross.json
+++ b/src/main/resources/assets/jmx/models/block/v1/3/jmx_cross.json
@@ -3,11 +3,6 @@
     "textures": {
         "particle": "#cross"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -176,5 +171,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/3/jmx_cube_all.json
+++ b/src/main/resources/assets/jmx/models/block/v1/3/jmx_cube_all.json
@@ -11,7 +11,6 @@
     },
     "jmx": {
         "textures": {
-            "particle": "#jmx_tex_particle",
             "layered_textures": [
                 {
                     "jmx_tex_down": "#jmx_tex_all",
@@ -37,7 +36,8 @@
                     "jmx_tex_south": "#jmx_tex_all",
                     "jmx_tex_west": "#jmx_tex_all"
                 }
-            ]
+            ],
+            "particle": "#jmx_tex_particle"
         },
         "materials": [
             {

--- a/src/main/resources/assets/jmx/models/block/v1/3/jmx_cube_bottom_top.json
+++ b/src/main/resources/assets/jmx/models/block/v1/3/jmx_cube_bottom_top.json
@@ -11,7 +11,6 @@
     },
     "jmx": {
         "textures": {
-            "particle": "#jmx_tex_particle",
             "layered_textures": [
                 {
                     "jmx_tex_down": "#jmx_tex_bottom",
@@ -37,84 +36,85 @@
                     "jmx_tex_south": "#jmx_tex_side",
                     "jmx_tex_west": "#jmx_tex_side"
                 }
-            ]
+            ],
+            "particle": "#jmx_tex_particle"
         },
         "materials": [
             {
-                "jmx_mat_down": "#jmx_mat_all",
-                "jmx_mat_up": "#jmx_mat_all",
-                "jmx_mat_north": "#jmx_mat_all",
-                "jmx_mat_east": "#jmx_mat_all",
-                "jmx_mat_south": "#jmx_mat_all",
-                "jmx_mat_west": "#jmx_mat_all"
+                "jmx_mat_down": "#jmx_mat_bottom",
+                "jmx_mat_up": "#jmx_mat_top",
+                "jmx_mat_north": "#jmx_mat_side",
+                "jmx_mat_east": "#jmx_mat_side",
+                "jmx_mat_south": "#jmx_mat_side",
+                "jmx_mat_west": "#jmx_mat_side"
             },
             {
-                "jmx_mat_down": "#jmx_mat_all",
-                "jmx_mat_up": "#jmx_mat_all",
-                "jmx_mat_north": "#jmx_mat_all",
-                "jmx_mat_east": "#jmx_mat_all",
-                "jmx_mat_south": "#jmx_mat_all",
-                "jmx_mat_west": "#jmx_mat_all"
+                "jmx_mat_down": "#jmx_mat_bottom",
+                "jmx_mat_up": "#jmx_mat_top",
+                "jmx_mat_north": "#jmx_mat_side",
+                "jmx_mat_east": "#jmx_mat_side",
+                "jmx_mat_south": "#jmx_mat_side",
+                "jmx_mat_west": "#jmx_mat_side"
             },
             {
-                "jmx_mat_down": "#jmx_mat_all",
-                "jmx_mat_up": "#jmx_mat_all",
-                "jmx_mat_north": "#jmx_mat_all",
-                "jmx_mat_east": "#jmx_mat_all",
-                "jmx_mat_south": "#jmx_mat_all",
-                "jmx_mat_west": "#jmx_mat_all"
+                "jmx_mat_down": "#jmx_mat_bottom",
+                "jmx_mat_up": "#jmx_mat_top",
+                "jmx_mat_north": "#jmx_mat_side",
+                "jmx_mat_east": "#jmx_mat_side",
+                "jmx_mat_south": "#jmx_mat_side",
+                "jmx_mat_west": "#jmx_mat_side"
             }
         ],
         "tags": [
             {
-                "jmx_tag_down": "#jmx_tag_all",
-                "jmx_tag_up": "#jmx_tag_all",
-                "jmx_tag_north": "#jmx_tag_all",
-                "jmx_tag_east": "#jmx_tag_all",
-                "jmx_tag_south": "#jmx_tag_all",
-                "jmx_tag_west": "#jmx_tag_all"
+                "jmx_tag_down": "#jmx_tag_bottom",
+                "jmx_tag_up": "#jmx_tag_top",
+                "jmx_tag_north": "#jmx_tag_side",
+                "jmx_tag_east": "#jmx_tag_side",
+                "jmx_tag_south": "#jmx_tag_side",
+                "jmx_tag_west": "#jmx_tag_side"
             },
             {
-                "jmx_tag_down": "#jmx_tag_all",
-                "jmx_tag_up": "#jmx_tag_all",
-                "jmx_tag_north": "#jmx_tag_all",
-                "jmx_tag_east": "#jmx_tag_all",
-                "jmx_tag_south": "#jmx_tag_all",
-                "jmx_tag_west": "#jmx_tag_all"
+                "jmx_tag_down": "#jmx_tag_bottom",
+                "jmx_tag_up": "#jmx_tag_top",
+                "jmx_tag_north": "#jmx_tag_side",
+                "jmx_tag_east": "#jmx_tag_side",
+                "jmx_tag_south": "#jmx_tag_side",
+                "jmx_tag_west": "#jmx_tag_side"
             },
             {
-                "jmx_tag_down": "#jmx_tag_all",
-                "jmx_tag_up": "#jmx_tag_all",
-                "jmx_tag_north": "#jmx_tag_all",
-                "jmx_tag_east": "#jmx_tag_all",
-                "jmx_tag_south": "#jmx_tag_all",
-                "jmx_tag_west": "#jmx_tag_all"
+                "jmx_tag_down": "#jmx_tag_bottom",
+                "jmx_tag_up": "#jmx_tag_top",
+                "jmx_tag_north": "#jmx_tag_side",
+                "jmx_tag_east": "#jmx_tag_side",
+                "jmx_tag_south": "#jmx_tag_side",
+                "jmx_tag_west": "#jmx_tag_side"
             }
         ],
         "colors": [
             {
-                "jmx_color_down": "#jmx_color_all",
-                "jmx_color_up": "#jmx_color_all",
-                "jmx_color_north": "#jmx_color_all",
-                "jmx_color_east": "#jmx_color_all",
-                "jmx_color_south": "#jmx_color_all",
-                "jmx_color_west": "#jmx_color_all"
+                "jmx_color_down": "#jmx_color_bottom",
+                "jmx_color_up": "#jmx_color_top",
+                "jmx_color_north": "#jmx_color_side",
+                "jmx_color_east": "#jmx_color_side",
+                "jmx_color_south": "#jmx_color_side",
+                "jmx_color_west": "#jmx_color_side"
             },
             {
-                "jmx_color_down": "#jmx_color_all",
-                "jmx_color_up": "#jmx_color_all",
-                "jmx_color_north": "#jmx_color_all",
-                "jmx_color_east": "#jmx_color_all",
-                "jmx_color_south": "#jmx_color_all",
-                "jmx_color_west": "#jmx_color_all"
+                "jmx_color_down": "#jmx_color_bottom",
+                "jmx_color_up": "#jmx_color_top",
+                "jmx_color_north": "#jmx_color_side",
+                "jmx_color_east": "#jmx_color_side",
+                "jmx_color_south": "#jmx_color_side",
+                "jmx_color_west": "#jmx_color_side"
             },
             {
-                "jmx_color_down": "#jmx_color_all",
-                "jmx_color_up": "#jmx_color_all",
-                "jmx_color_north": "#jmx_color_all",
-                "jmx_color_east": "#jmx_color_all",
-                "jmx_color_south": "#jmx_color_all",
-                "jmx_color_west": "#jmx_color_all"
+                "jmx_color_down": "#jmx_color_bottom",
+                "jmx_color_up": "#jmx_color_top",
+                "jmx_color_north": "#jmx_color_side",
+                "jmx_color_east": "#jmx_color_side",
+                "jmx_color_south": "#jmx_color_side",
+                "jmx_color_west": "#jmx_color_side"
             }
         ]
     },

--- a/src/main/resources/assets/jmx/models/block/v1/3/jmx_cube_column.json
+++ b/src/main/resources/assets/jmx/models/block/v1/3/jmx_cube_column.json
@@ -11,7 +11,6 @@
     },
     "jmx": {
         "textures": {
-            "particle": "#jmx_tex_particle",
             "layered_textures": [
                 {
                     "jmx_tex_down": "#jmx_tex_end",
@@ -37,84 +36,85 @@
                     "jmx_tex_south": "#jmx_tex_side",
                     "jmx_tex_west": "#jmx_tex_side"
                 }
-            ]
+            ],
+            "particle": "#jmx_tex_particle"
         },
         "materials": [
             {
-                "jmx_mat_down": "#jmx_mat_all",
-                "jmx_mat_up": "#jmx_mat_all",
-                "jmx_mat_north": "#jmx_mat_all",
-                "jmx_mat_east": "#jmx_mat_all",
-                "jmx_mat_south": "#jmx_mat_all",
-                "jmx_mat_west": "#jmx_mat_all"
+                "jmx_mat_down": "#jmx_mat_end",
+                "jmx_mat_up": "#jmx_mat_end",
+                "jmx_mat_north": "#jmx_mat_side",
+                "jmx_mat_east": "#jmx_mat_side",
+                "jmx_mat_south": "#jmx_mat_side",
+                "jmx_mat_west": "#jmx_mat_side"
             },
             {
-                "jmx_mat_down": "#jmx_mat_all",
-                "jmx_mat_up": "#jmx_mat_all",
-                "jmx_mat_north": "#jmx_mat_all",
-                "jmx_mat_east": "#jmx_mat_all",
-                "jmx_mat_south": "#jmx_mat_all",
-                "jmx_mat_west": "#jmx_mat_all"
+                "jmx_mat_down": "#jmx_mat_end",
+                "jmx_mat_up": "#jmx_mat_end",
+                "jmx_mat_north": "#jmx_mat_side",
+                "jmx_mat_east": "#jmx_mat_side",
+                "jmx_mat_south": "#jmx_mat_side",
+                "jmx_mat_west": "#jmx_mat_side"
             },
             {
-                "jmx_mat_down": "#jmx_mat_all",
-                "jmx_mat_up": "#jmx_mat_all",
-                "jmx_mat_north": "#jmx_mat_all",
-                "jmx_mat_east": "#jmx_mat_all",
-                "jmx_mat_south": "#jmx_mat_all",
-                "jmx_mat_west": "#jmx_mat_all"
+                "jmx_mat_down": "#jmx_mat_end",
+                "jmx_mat_up": "#jmx_mat_end",
+                "jmx_mat_north": "#jmx_mat_side",
+                "jmx_mat_east": "#jmx_mat_side",
+                "jmx_mat_south": "#jmx_mat_side",
+                "jmx_mat_west": "#jmx_mat_side"
             }
         ],
         "tags": [
             {
-                "jmx_tag_down": "#jmx_tag_all",
-                "jmx_tag_up": "#jmx_tag_all",
-                "jmx_tag_north": "#jmx_tag_all",
-                "jmx_tag_east": "#jmx_tag_all",
-                "jmx_tag_south": "#jmx_tag_all",
-                "jmx_tag_west": "#jmx_tag_all"
+                "jmx_tag_down": "#jmx_tag_end",
+                "jmx_tag_up": "#jmx_tag_end",
+                "jmx_tag_north": "#jmx_tag_side",
+                "jmx_tag_east": "#jmx_tag_side",
+                "jmx_tag_south": "#jmx_tag_side",
+                "jmx_tag_west": "#jmx_tag_side"
             },
             {
-                "jmx_tag_down": "#jmx_tag_all",
-                "jmx_tag_up": "#jmx_tag_all",
-                "jmx_tag_north": "#jmx_tag_all",
-                "jmx_tag_east": "#jmx_tag_all",
-                "jmx_tag_south": "#jmx_tag_all",
-                "jmx_tag_west": "#jmx_tag_all"
+                "jmx_tag_down": "#jmx_tag_end",
+                "jmx_tag_up": "#jmx_tag_end",
+                "jmx_tag_north": "#jmx_tag_side",
+                "jmx_tag_east": "#jmx_tag_side",
+                "jmx_tag_south": "#jmx_tag_side",
+                "jmx_tag_west": "#jmx_tag_side"
             },
             {
-                "jmx_tag_down": "#jmx_tag_all",
-                "jmx_tag_up": "#jmx_tag_all",
-                "jmx_tag_north": "#jmx_tag_all",
-                "jmx_tag_east": "#jmx_tag_all",
-                "jmx_tag_south": "#jmx_tag_all",
-                "jmx_tag_west": "#jmx_tag_all"
+                "jmx_tag_down": "#jmx_tag_end",
+                "jmx_tag_up": "#jmx_tag_end",
+                "jmx_tag_north": "#jmx_tag_side",
+                "jmx_tag_east": "#jmx_tag_side",
+                "jmx_tag_south": "#jmx_tag_side",
+                "jmx_tag_west": "#jmx_tag_side"
             }
         ],
         "colors": [
             {
-                "jmx_color_down": "#jmx_color_all",
-                "jmx_color_up": "#jmx_color_all",
-                "jmx_color_north": "#jmx_color_all",
-                "jmx_color_east": "#jmx_color_all",
-                "jmx_color_south": "#jmx_color_all",
-                "jmx_color_west": "#jmx_color_all"
+                "jmx_color_down": "#jmx_color_end",
+                "jmx_color_up": "#jmx_color_end",
+                "jmx_color_north": "#jmx_color_side",
+                "jmx_color_east": "#jmx_color_side",
+                "jmx_color_south": "#jmx_color_side",
+                "jmx_color_west": "#jmx_color_side"
             },
             {
-                "jmx_color_down": "#jmx_color_all",
-                "jmx_color_up": "#jmx_color_all",
-                "jmx_color_north": "#jmx_color_all",
-                "jmx_color_east": "#jmx_color_all",
-                "jmx_color_south": "#jmx_color_all",
-                "jmx_color_west": "#jmx_color_all"
+                "jmx_color_down": "#jmx_color_end",
+                "jmx_color_up": "#jmx_color_end",
+                "jmx_color_north": "#jmx_color_side",
+                "jmx_color_east": "#jmx_color_side",
+                "jmx_color_south": "#jmx_color_side",
+                "jmx_color_west": "#jmx_color_side"
             },
             {
-                "jmx_color_down": "#jmx_color_all",
-                "jmx_color_up": "#jmx_color_all",
-                "jmx_color_north": "#jmx_color_all",
-                "jmx_color_east": "#jmx_color_all",
-                "jmx_color_south": "#jmx_color_all",
-                "jmx_color_west": "#jmx_color_all"
+                "jmx_color_down": "#jmx_color_end",
+                "jmx_color_up": "#jmx_color_end",
+                "jmx_color_north": "#jmx_color_side",
+                "jmx_color_east": "#jmx_color_side",
+                "jmx_color_south": "#jmx_color_side",
+                "jmx_color_west": "#jmx_color_side"
             }
         ]
     },

--- a/src/main/resources/assets/jmx/models/block/v1/3/jmx_cube_mirrored_all.json
+++ b/src/main/resources/assets/jmx/models/block/v1/3/jmx_cube_mirrored_all.json
@@ -11,7 +11,6 @@
     },
     "jmx": {
         "textures": {
-            "particle": "#jmx_tex_particle",
             "layered_textures": [
                 {
                     "jmx_tex_down": "#jmx_tex_all",
@@ -37,7 +36,8 @@
                     "jmx_tex_south": "#jmx_tex_all",
                     "jmx_tex_west": "#jmx_tex_all"
                 }
-            ]
+            ],
+            "particle": "#jmx_tex_particle"
         },
         "materials": [
             {

--- a/src/main/resources/assets/jmx/models/block/v1/3/jmx_cube_top.json
+++ b/src/main/resources/assets/jmx/models/block/v1/3/jmx_cube_top.json
@@ -11,7 +11,6 @@
     },
     "jmx": {
         "textures": {
-            "particle": "#jmx_tex_particle",
             "layered_textures": [
                 {
                     "jmx_tex_down": "#jmx_tex_side",
@@ -37,84 +36,85 @@
                     "jmx_tex_south": "#jmx_tex_side",
                     "jmx_tex_west": "#jmx_tex_side"
                 }
-            ]
+            ],
+            "particle": "#jmx_tex_particle"
         },
         "materials": [
             {
-                "jmx_mat_down": "#jmx_mat_all",
-                "jmx_mat_up": "#jmx_mat_all",
-                "jmx_mat_north": "#jmx_mat_all",
-                "jmx_mat_east": "#jmx_mat_all",
-                "jmx_mat_south": "#jmx_mat_all",
-                "jmx_mat_west": "#jmx_mat_all"
+                "jmx_mat_down": "#jmx_mat_side",
+                "jmx_mat_up": "#jmx_mat_top",
+                "jmx_mat_north": "#jmx_mat_side",
+                "jmx_mat_east": "#jmx_mat_side",
+                "jmx_mat_south": "#jmx_mat_side",
+                "jmx_mat_west": "#jmx_mat_side"
             },
             {
-                "jmx_mat_down": "#jmx_mat_all",
-                "jmx_mat_up": "#jmx_mat_all",
-                "jmx_mat_north": "#jmx_mat_all",
-                "jmx_mat_east": "#jmx_mat_all",
-                "jmx_mat_south": "#jmx_mat_all",
-                "jmx_mat_west": "#jmx_mat_all"
+                "jmx_mat_down": "#jmx_mat_side",
+                "jmx_mat_up": "#jmx_mat_top",
+                "jmx_mat_north": "#jmx_mat_side",
+                "jmx_mat_east": "#jmx_mat_side",
+                "jmx_mat_south": "#jmx_mat_side",
+                "jmx_mat_west": "#jmx_mat_side"
             },
             {
-                "jmx_mat_down": "#jmx_mat_all",
-                "jmx_mat_up": "#jmx_mat_all",
-                "jmx_mat_north": "#jmx_mat_all",
-                "jmx_mat_east": "#jmx_mat_all",
-                "jmx_mat_south": "#jmx_mat_all",
-                "jmx_mat_west": "#jmx_mat_all"
+                "jmx_mat_down": "#jmx_mat_side",
+                "jmx_mat_up": "#jmx_mat_top",
+                "jmx_mat_north": "#jmx_mat_side",
+                "jmx_mat_east": "#jmx_mat_side",
+                "jmx_mat_south": "#jmx_mat_side",
+                "jmx_mat_west": "#jmx_mat_side"
             }
         ],
         "tags": [
             {
-                "jmx_tag_down": "#jmx_tag_all",
-                "jmx_tag_up": "#jmx_tag_all",
-                "jmx_tag_north": "#jmx_tag_all",
-                "jmx_tag_east": "#jmx_tag_all",
-                "jmx_tag_south": "#jmx_tag_all",
-                "jmx_tag_west": "#jmx_tag_all"
+                "jmx_tag_down": "#jmx_tag_side",
+                "jmx_tag_up": "#jmx_tag_top",
+                "jmx_tag_north": "#jmx_tag_side",
+                "jmx_tag_east": "#jmx_tag_side",
+                "jmx_tag_south": "#jmx_tag_side",
+                "jmx_tag_west": "#jmx_tag_side"
             },
             {
-                "jmx_tag_down": "#jmx_tag_all",
-                "jmx_tag_up": "#jmx_tag_all",
-                "jmx_tag_north": "#jmx_tag_all",
-                "jmx_tag_east": "#jmx_tag_all",
-                "jmx_tag_south": "#jmx_tag_all",
-                "jmx_tag_west": "#jmx_tag_all"
+                "jmx_tag_down": "#jmx_tag_side",
+                "jmx_tag_up": "#jmx_tag_top",
+                "jmx_tag_north": "#jmx_tag_side",
+                "jmx_tag_east": "#jmx_tag_side",
+                "jmx_tag_south": "#jmx_tag_side",
+                "jmx_tag_west": "#jmx_tag_side"
             },
             {
-                "jmx_tag_down": "#jmx_tag_all",
-                "jmx_tag_up": "#jmx_tag_all",
-                "jmx_tag_north": "#jmx_tag_all",
-                "jmx_tag_east": "#jmx_tag_all",
-                "jmx_tag_south": "#jmx_tag_all",
-                "jmx_tag_west": "#jmx_tag_all"
+                "jmx_tag_down": "#jmx_tag_side",
+                "jmx_tag_up": "#jmx_tag_top",
+                "jmx_tag_north": "#jmx_tag_side",
+                "jmx_tag_east": "#jmx_tag_side",
+                "jmx_tag_south": "#jmx_tag_side",
+                "jmx_tag_west": "#jmx_tag_side"
             }
         ],
         "colors": [
             {
-                "jmx_color_down": "#jmx_color_all",
-                "jmx_color_up": "#jmx_color_all",
-                "jmx_color_north": "#jmx_color_all",
-                "jmx_color_east": "#jmx_color_all",
-                "jmx_color_south": "#jmx_color_all",
-                "jmx_color_west": "#jmx_color_all"
+                "jmx_color_down": "#jmx_color_side",
+                "jmx_color_up": "#jmx_color_top",
+                "jmx_color_north": "#jmx_color_side",
+                "jmx_color_east": "#jmx_color_side",
+                "jmx_color_south": "#jmx_color_side",
+                "jmx_color_west": "#jmx_color_side"
             },
             {
-                "jmx_color_down": "#jmx_color_all",
-                "jmx_color_up": "#jmx_color_all",
-                "jmx_color_north": "#jmx_color_all",
-                "jmx_color_east": "#jmx_color_all",
-                "jmx_color_south": "#jmx_color_all",
-                "jmx_color_west": "#jmx_color_all"
+                "jmx_color_down": "#jmx_color_side",
+                "jmx_color_up": "#jmx_color_top",
+                "jmx_color_north": "#jmx_color_side",
+                "jmx_color_east": "#jmx_color_side",
+                "jmx_color_south": "#jmx_color_side",
+                "jmx_color_west": "#jmx_color_side"
             },
             {
-                "jmx_color_down": "#jmx_color_all",
-                "jmx_color_up": "#jmx_color_all",
-                "jmx_color_north": "#jmx_color_all",
-                "jmx_color_east": "#jmx_color_all",
-                "jmx_color_south": "#jmx_color_all",
-                "jmx_color_west": "#jmx_color_all"
+                "jmx_color_down": "#jmx_color_side",
+                "jmx_color_up": "#jmx_color_top",
+                "jmx_color_north": "#jmx_color_side",
+                "jmx_color_east": "#jmx_color_side",
+                "jmx_color_south": "#jmx_color_side",
+                "jmx_color_west": "#jmx_color_side"
             }
         ]
     },

--- a/src/main/resources/assets/jmx/models/block/v1/3/jmx_door_bottom.json
+++ b/src/main/resources/assets/jmx/models/block/v1/3/jmx_door_bottom.json
@@ -3,11 +3,6 @@
     "textures": {
         "particle": "#bottom"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -173,5 +168,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/3/jmx_door_bottom_rh.json
+++ b/src/main/resources/assets/jmx/models/block/v1/3/jmx_door_bottom_rh.json
@@ -3,11 +3,6 @@
     "textures": {
         "particle": "#bottom"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -173,5 +168,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/3/jmx_door_top.json
+++ b/src/main/resources/assets/jmx/models/block/v1/3/jmx_door_top.json
@@ -3,11 +3,6 @@
     "textures": {
         "particle": "#top"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -173,5 +168,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/3/jmx_door_top_rh.json
+++ b/src/main/resources/assets/jmx/models/block/v1/3/jmx_door_top_rh.json
@@ -3,11 +3,6 @@
     "textures": {
         "particle": "#top"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -173,5 +168,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/3/jmx_fence_inventory.json
+++ b/src/main/resources/assets/jmx/models/block/v1/3/jmx_fence_inventory.json
@@ -40,11 +40,6 @@
     "textures": {
         "particle": "#texture"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -805,5 +800,10 @@
             "__comment": "Lower bar"
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/3/jmx_fence_post.json
+++ b/src/main/resources/assets/jmx/models/block/v1/3/jmx_fence_post.json
@@ -2,11 +2,6 @@
     "textures": {
         "particle": "#texture"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -200,5 +195,10 @@
             "__comment": "Center post"
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/3/jmx_fence_side.json
+++ b/src/main/resources/assets/jmx/models/block/v1/3/jmx_fence_side.json
@@ -2,11 +2,6 @@
     "textures": {
         "particle": "#texture"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -331,5 +326,10 @@
             "__comment": "lower bar"
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/3/jmx_orientable.json
+++ b/src/main/resources/assets/jmx/models/block/v1/3/jmx_orientable.json
@@ -19,35 +19,35 @@
         },
         "materials": [
             {
-                "jmx_mat_down": "#jmx_mat_top"
+                "jmx_mat_bottom": "#jmx_mat_top"
             },
             {
-                "jmx_mat_down": "#jmx_mat_top"
+                "jmx_mat_bottom": "#jmx_mat_top"
             },
             {
-                "jmx_mat_down": "#jmx_mat_top"
+                "jmx_mat_bottom": "#jmx_mat_top"
             }
         ],
         "tags": [
             {
-                "jmx_tag_down": "#jmx_tag_top"
+                "jmx_tag_bottom": "#jmx_tag_top"
             },
             {
-                "jmx_tag_down": "#jmx_tag_top"
+                "jmx_tag_bottom": "#jmx_tag_top"
             },
             {
-                "jmx_tag_down": "#jmx_tag_top"
+                "jmx_tag_bottom": "#jmx_tag_top"
             }
         ],
         "colors": [
             {
-                "jmx_color_down": "#jmx_color_top"
+                "jmx_color_bottom": "#jmx_color_top"
             },
             {
-                "jmx_color_down": "#jmx_color_top"
+                "jmx_color_bottom": "#jmx_color_top"
             },
             {
-                "jmx_color_down": "#jmx_color_top"
+                "jmx_color_bottom": "#jmx_color_top"
             }
         ]
     },

--- a/src/main/resources/assets/jmx/models/block/v1/3/jmx_orientable_vertical.json
+++ b/src/main/resources/assets/jmx/models/block/v1/3/jmx_orientable_vertical.json
@@ -11,7 +11,6 @@
     },
     "jmx": {
         "textures": {
-            "particle": "#jmx_tex_particle",
             "layered_textures": [
                 {
                     "jmx_tex_down": "#jmx_tex_side",
@@ -37,84 +36,85 @@
                     "jmx_tex_south": "#jmx_tex_side",
                     "jmx_tex_west": "#jmx_tex_side"
                 }
-            ]
+            ],
+            "particle": "#jmx_tex_particle"
         },
         "materials": [
             {
-                "jmx_mat_down": "#jmx_mat_all",
+                "jmx_mat_down": "#jmx_mat_side",
                 "jmx_mat_up": "#jmx_mat_front",
-                "jmx_mat_north": "#jmx_mat_all",
-                "jmx_mat_east": "#jmx_mat_all",
-                "jmx_mat_south": "#jmx_mat_all",
-                "jmx_mat_west": "#jmx_mat_all"
+                "jmx_mat_north": "#jmx_mat_side",
+                "jmx_mat_east": "#jmx_mat_side",
+                "jmx_mat_south": "#jmx_mat_side",
+                "jmx_mat_west": "#jmx_mat_side"
             },
             {
-                "jmx_mat_down": "#jmx_mat_all",
+                "jmx_mat_down": "#jmx_mat_side",
                 "jmx_mat_up": "#jmx_mat_front",
-                "jmx_mat_north": "#jmx_mat_all",
-                "jmx_mat_east": "#jmx_mat_all",
-                "jmx_mat_south": "#jmx_mat_all",
-                "jmx_mat_west": "#jmx_mat_all"
+                "jmx_mat_north": "#jmx_mat_side",
+                "jmx_mat_east": "#jmx_mat_side",
+                "jmx_mat_south": "#jmx_mat_side",
+                "jmx_mat_west": "#jmx_mat_side"
             },
             {
-                "jmx_mat_down": "#jmx_mat_all",
+                "jmx_mat_down": "#jmx_mat_side",
                 "jmx_mat_up": "#jmx_mat_front",
-                "jmx_mat_north": "#jmx_mat_all",
-                "jmx_mat_east": "#jmx_mat_all",
-                "jmx_mat_south": "#jmx_mat_all",
-                "jmx_mat_west": "#jmx_mat_all"
+                "jmx_mat_north": "#jmx_mat_side",
+                "jmx_mat_east": "#jmx_mat_side",
+                "jmx_mat_south": "#jmx_mat_side",
+                "jmx_mat_west": "#jmx_mat_side"
             }
         ],
         "tags": [
             {
-                "jmx_tag_down": "#jmx_tag_all",
+                "jmx_tag_down": "#jmx_tag_side",
                 "jmx_tag_up": "#jmx_tag_front",
-                "jmx_tag_north": "#jmx_tag_all",
-                "jmx_tag_east": "#jmx_tag_all",
-                "jmx_tag_south": "#jmx_tag_all",
-                "jmx_tag_west": "#jmx_tag_all"
+                "jmx_tag_north": "#jmx_tag_side",
+                "jmx_tag_east": "#jmx_tag_side",
+                "jmx_tag_south": "#jmx_tag_side",
+                "jmx_tag_west": "#jmx_tag_side"
             },
             {
-                "jmx_tag_down": "#jmx_tag_all",
+                "jmx_tag_down": "#jmx_tag_side",
                 "jmx_tag_up": "#jmx_tag_front",
-                "jmx_tag_north": "#jmx_tag_all",
-                "jmx_tag_east": "#jmx_tag_all",
-                "jmx_tag_south": "#jmx_tag_all",
-                "jmx_tag_west": "#jmx_tag_all"
+                "jmx_tag_north": "#jmx_tag_side",
+                "jmx_tag_east": "#jmx_tag_side",
+                "jmx_tag_south": "#jmx_tag_side",
+                "jmx_tag_west": "#jmx_tag_side"
             },
             {
-                "jmx_tag_down": "#jmx_tag_all",
+                "jmx_tag_down": "#jmx_tag_side",
                 "jmx_tag_up": "#jmx_tag_front",
-                "jmx_tag_north": "#jmx_tag_all",
-                "jmx_tag_east": "#jmx_tag_all",
-                "jmx_tag_south": "#jmx_tag_all",
-                "jmx_tag_west": "#jmx_tag_all"
+                "jmx_tag_north": "#jmx_tag_side",
+                "jmx_tag_east": "#jmx_tag_side",
+                "jmx_tag_south": "#jmx_tag_side",
+                "jmx_tag_west": "#jmx_tag_side"
             }
         ],
         "colors": [
             {
-                "jmx_color_down": "#jmx_color_all",
+                "jmx_color_down": "#jmx_color_side",
                 "jmx_color_up": "#jmx_color_front",
-                "jmx_color_north": "#jmx_color_all",
-                "jmx_color_east": "#jmx_color_all",
-                "jmx_color_south": "#jmx_color_all",
-                "jmx_color_west": "#jmx_color_all"
+                "jmx_color_north": "#jmx_color_side",
+                "jmx_color_east": "#jmx_color_side",
+                "jmx_color_south": "#jmx_color_side",
+                "jmx_color_west": "#jmx_color_side"
             },
             {
-                "jmx_color_down": "#jmx_color_all",
+                "jmx_color_down": "#jmx_color_side",
                 "jmx_color_up": "#jmx_color_front",
-                "jmx_color_north": "#jmx_color_all",
-                "jmx_color_east": "#jmx_color_all",
-                "jmx_color_south": "#jmx_color_all",
-                "jmx_color_west": "#jmx_color_all"
+                "jmx_color_north": "#jmx_color_side",
+                "jmx_color_east": "#jmx_color_side",
+                "jmx_color_south": "#jmx_color_side",
+                "jmx_color_west": "#jmx_color_side"
             },
             {
-                "jmx_color_down": "#jmx_color_all",
+                "jmx_color_down": "#jmx_color_side",
                 "jmx_color_up": "#jmx_color_front",
-                "jmx_color_north": "#jmx_color_all",
-                "jmx_color_east": "#jmx_color_all",
-                "jmx_color_south": "#jmx_color_all",
-                "jmx_color_west": "#jmx_color_all"
+                "jmx_color_north": "#jmx_color_side",
+                "jmx_color_east": "#jmx_color_side",
+                "jmx_color_south": "#jmx_color_side",
+                "jmx_color_west": "#jmx_color_side"
             }
         ]
     },

--- a/src/main/resources/assets/jmx/models/block/v1/3/jmx_orientable_with_bottom.json
+++ b/src/main/resources/assets/jmx/models/block/v1/3/jmx_orientable_with_bottom.json
@@ -30,7 +30,6 @@
     },
     "jmx": {
         "textures": {
-            "particle": "#jmx_tex_particle",
             "layered_textures": [
                 {
                     "jmx_tex_down": "#jmx_tex_bottom",
@@ -56,32 +55,33 @@
                     "jmx_tex_south": "#jmx_tex_side",
                     "jmx_tex_west": "#jmx_tex_side"
                 }
-            ]
+            ],
+            "particle": "#jmx_tex_particle"
         },
         "materials": [
             {
                 "jmx_mat_down": "#jmx_mat_bottom",
                 "jmx_mat_up": "#jmx_mat_top",
                 "jmx_mat_north": "#jmx_mat_front",
-                "jmx_mat_east": "#jmx_mat_all",
-                "jmx_mat_south": "#jmx_mat_all",
-                "jmx_mat_west": "#jmx_mat_all"
+                "jmx_mat_east": "#jmx_mat_side",
+                "jmx_mat_south": "#jmx_mat_side",
+                "jmx_mat_west": "#jmx_mat_side"
             },
             {
                 "jmx_mat_down": "#jmx_mat_bottom",
                 "jmx_mat_up": "#jmx_mat_top",
                 "jmx_mat_north": "#jmx_mat_front",
-                "jmx_mat_east": "#jmx_mat_all",
-                "jmx_mat_south": "#jmx_mat_all",
-                "jmx_mat_west": "#jmx_mat_all"
+                "jmx_mat_east": "#jmx_mat_side",
+                "jmx_mat_south": "#jmx_mat_side",
+                "jmx_mat_west": "#jmx_mat_side"
             },
             {
                 "jmx_mat_down": "#jmx_mat_bottom",
                 "jmx_mat_up": "#jmx_mat_top",
                 "jmx_mat_north": "#jmx_mat_front",
-                "jmx_mat_east": "#jmx_mat_all",
-                "jmx_mat_south": "#jmx_mat_all",
-                "jmx_mat_west": "#jmx_mat_all"
+                "jmx_mat_east": "#jmx_mat_side",
+                "jmx_mat_south": "#jmx_mat_side",
+                "jmx_mat_west": "#jmx_mat_side"
             }
         ],
         "tags": [
@@ -89,25 +89,25 @@
                 "jmx_tag_down": "#jmx_tag_bottom",
                 "jmx_tag_up": "#jmx_tag_top",
                 "jmx_tag_north": "#jmx_tag_front",
-                "jmx_tag_east": "#jmx_tag_all",
-                "jmx_tag_south": "#jmx_tag_all",
-                "jmx_tag_west": "#jmx_tag_all"
+                "jmx_tag_east": "#jmx_tag_side",
+                "jmx_tag_south": "#jmx_tag_side",
+                "jmx_tag_west": "#jmx_tag_side"
             },
             {
                 "jmx_tag_down": "#jmx_tag_bottom",
                 "jmx_tag_up": "#jmx_tag_top",
                 "jmx_tag_north": "#jmx_tag_front",
-                "jmx_tag_east": "#jmx_tag_all",
-                "jmx_tag_south": "#jmx_tag_all",
-                "jmx_tag_west": "#jmx_tag_all"
+                "jmx_tag_east": "#jmx_tag_side",
+                "jmx_tag_south": "#jmx_tag_side",
+                "jmx_tag_west": "#jmx_tag_side"
             },
             {
                 "jmx_tag_down": "#jmx_tag_bottom",
                 "jmx_tag_up": "#jmx_tag_top",
                 "jmx_tag_north": "#jmx_tag_front",
-                "jmx_tag_east": "#jmx_tag_all",
-                "jmx_tag_south": "#jmx_tag_all",
-                "jmx_tag_west": "#jmx_tag_all"
+                "jmx_tag_east": "#jmx_tag_side",
+                "jmx_tag_south": "#jmx_tag_side",
+                "jmx_tag_west": "#jmx_tag_side"
             }
         ],
         "colors": [
@@ -115,25 +115,25 @@
                 "jmx_color_down": "#jmx_color_bottom",
                 "jmx_color_up": "#jmx_color_top",
                 "jmx_color_north": "#jmx_color_front",
-                "jmx_color_east": "#jmx_color_all",
-                "jmx_color_south": "#jmx_color_all",
-                "jmx_color_west": "#jmx_color_all"
+                "jmx_color_east": "#jmx_color_side",
+                "jmx_color_south": "#jmx_color_side",
+                "jmx_color_west": "#jmx_color_side"
             },
             {
                 "jmx_color_down": "#jmx_color_bottom",
                 "jmx_color_up": "#jmx_color_top",
                 "jmx_color_north": "#jmx_color_front",
-                "jmx_color_east": "#jmx_color_all",
-                "jmx_color_south": "#jmx_color_all",
-                "jmx_color_west": "#jmx_color_all"
+                "jmx_color_east": "#jmx_color_side",
+                "jmx_color_south": "#jmx_color_side",
+                "jmx_color_west": "#jmx_color_side"
             },
             {
                 "jmx_color_down": "#jmx_color_bottom",
                 "jmx_color_up": "#jmx_color_top",
                 "jmx_color_north": "#jmx_color_front",
-                "jmx_color_east": "#jmx_color_all",
-                "jmx_color_south": "#jmx_color_all",
-                "jmx_color_west": "#jmx_color_all"
+                "jmx_color_east": "#jmx_color_side",
+                "jmx_color_south": "#jmx_color_side",
+                "jmx_color_west": "#jmx_color_side"
             }
         ]
     },

--- a/src/main/resources/assets/jmx/models/block/v1/3/jmx_slab.json
+++ b/src/main/resources/assets/jmx/models/block/v1/3/jmx_slab.json
@@ -3,11 +3,6 @@
     "textures": {
         "particle": "#side"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -203,5 +198,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/3/jmx_slab_top.json
+++ b/src/main/resources/assets/jmx/models/block/v1/3/jmx_slab_top.json
@@ -2,11 +2,6 @@
     "textures": {
         "particle": "#side"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -202,5 +197,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/3/jmx_stairs.json
+++ b/src/main/resources/assets/jmx/models/block/v1/3/jmx_stairs.json
@@ -56,11 +56,6 @@
     "textures": {
         "particle": "#side"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -419,5 +414,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/3/jmx_stem_fruit.json
+++ b/src/main/resources/assets/jmx/models/block/v1/3/jmx_stem_fruit.json
@@ -3,11 +3,6 @@
     "textures": {
         "particle": "#stem"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -200,22 +195,22 @@
                     "tintindex": 0,
                     "jmx_layers": [
                         {
-                            "texture": "#jmx_tex_stem",
-                            "material": "#jmx_mat_stem",
-                            "tag": "#jmx_tag_stem",
-                            "color": "#jmx_color_stem"
+                            "texture": "#jmx_tex_upperstem",
+                            "material": "#jmx_mat_upperstem",
+                            "tag": "#jmx_tag_upperstem",
+                            "color": "#jmx_color_upperstem"
                         },
                         {
-                            "texture": "#jmx_tex_stem",
-                            "material": "#jmx_mat_stem",
-                            "tag": "#jmx_tag_stem",
-                            "color": "#jmx_color_stem"
+                            "texture": "#jmx_tex_upperstem",
+                            "material": "#jmx_mat_upperstem",
+                            "tag": "#jmx_tag_upperstem",
+                            "color": "#jmx_color_upperstem"
                         },
                         {
-                            "texture": "#jmx_tex_stem",
-                            "material": "#jmx_mat_stem",
-                            "tag": "#jmx_tag_stem",
-                            "color": "#jmx_color_stem"
+                            "texture": "#jmx_tex_upperstem",
+                            "material": "#jmx_mat_upperstem",
+                            "tag": "#jmx_tag_upperstem",
+                            "color": "#jmx_color_upperstem"
                         }
                     ]
                 },
@@ -230,27 +225,32 @@
                     "tintindex": 0,
                     "jmx_layers": [
                         {
-                            "texture": "#jmx_tex_stem",
-                            "material": "#jmx_mat_stem",
-                            "tag": "#jmx_tag_stem",
-                            "color": "#jmx_color_stem"
+                            "texture": "#jmx_tex_upperstem",
+                            "material": "#jmx_mat_upperstem",
+                            "tag": "#jmx_tag_upperstem",
+                            "color": "#jmx_color_upperstem"
                         },
                         {
-                            "texture": "#jmx_tex_stem",
-                            "material": "#jmx_mat_stem",
-                            "tag": "#jmx_tag_stem",
-                            "color": "#jmx_color_stem"
+                            "texture": "#jmx_tex_upperstem",
+                            "material": "#jmx_mat_upperstem",
+                            "tag": "#jmx_tag_upperstem",
+                            "color": "#jmx_color_upperstem"
                         },
                         {
-                            "texture": "#jmx_tex_stem",
-                            "material": "#jmx_mat_stem",
-                            "tag": "#jmx_tag_stem",
-                            "color": "#jmx_color_stem"
+                            "texture": "#jmx_tex_upperstem",
+                            "material": "#jmx_mat_upperstem",
+                            "tag": "#jmx_tag_upperstem",
+                            "color": "#jmx_color_upperstem"
                         }
                     ]
                 }
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/3/jmx_stem_growth0.json
+++ b/src/main/resources/assets/jmx/models/block/v1/3/jmx_stem_growth0.json
@@ -3,11 +3,6 @@
     "textures": {
         "particle": "#stem"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -178,5 +173,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/3/jmx_stem_growth1.json
+++ b/src/main/resources/assets/jmx/models/block/v1/3/jmx_stem_growth1.json
@@ -3,11 +3,6 @@
     "textures": {
         "particle": "#stem"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -178,5 +173,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/3/jmx_stem_growth2.json
+++ b/src/main/resources/assets/jmx/models/block/v1/3/jmx_stem_growth2.json
@@ -3,11 +3,6 @@
     "textures": {
         "particle": "#stem"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -178,5 +173,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/3/jmx_stem_growth3.json
+++ b/src/main/resources/assets/jmx/models/block/v1/3/jmx_stem_growth3.json
@@ -3,11 +3,6 @@
     "textures": {
         "particle": "#stem"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -178,5 +173,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/3/jmx_stem_growth4.json
+++ b/src/main/resources/assets/jmx/models/block/v1/3/jmx_stem_growth4.json
@@ -3,11 +3,6 @@
     "textures": {
         "particle": "#stem"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -178,5 +173,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/3/jmx_stem_growth5.json
+++ b/src/main/resources/assets/jmx/models/block/v1/3/jmx_stem_growth5.json
@@ -3,11 +3,6 @@
     "textures": {
         "particle": "#stem"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -178,5 +173,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/3/jmx_stem_growth6.json
+++ b/src/main/resources/assets/jmx/models/block/v1/3/jmx_stem_growth6.json
@@ -3,11 +3,6 @@
     "textures": {
         "particle": "#stem"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -178,5 +173,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/3/jmx_stem_growth7.json
+++ b/src/main/resources/assets/jmx/models/block/v1/3/jmx_stem_growth7.json
@@ -3,11 +3,6 @@
     "textures": {
         "particle": "#stem"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -178,5 +173,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/3/jmx_template_farmland.json
+++ b/src/main/resources/assets/jmx/models/block/v1/3/jmx_template_farmland.json
@@ -1,5 +1,8 @@
 {
     "parent": "jmx:block/v1/block",
+    "textures": {
+        "particle": "#dirt"
+    },
     "elements": [
         {
             "from": [
@@ -195,5 +198,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/3/jmx_template_fence_gate.json
+++ b/src/main/resources/assets/jmx/models/block/v1/3/jmx_template_fence_gate.json
@@ -39,11 +39,6 @@
     "textures": {
         "particle": "#texture"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "__comment": "Left-hand post",
@@ -1328,5 +1323,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/3/jmx_template_fence_gate_open.json
+++ b/src/main/resources/assets/jmx/models/block/v1/3/jmx_template_fence_gate_open.json
@@ -2,11 +2,6 @@
     "textures": {
         "particle": "#texture"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "__comment": "Left-hand post",
@@ -1291,5 +1286,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/3/jmx_template_fence_gate_wall.json
+++ b/src/main/resources/assets/jmx/models/block/v1/3/jmx_template_fence_gate_wall.json
@@ -3,11 +3,6 @@
     "textures": {
         "particle": "#texture"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "__comment": "Left-hand post",
@@ -918,7 +913,27 @@
                         6,
                         9
                     ],
-                    "texture": "#texture"
+                    "texture": "#texture",
+                    "jmx_layers": [
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        },
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        },
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        }
+                    ]
                 },
                 "up": {
                     "uv": [
@@ -927,7 +942,27 @@
                         6,
                         9
                     ],
-                    "texture": "#texture"
+                    "texture": "#texture",
+                    "jmx_layers": [
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        },
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        },
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        }
+                    ]
                 },
                 "north": {
                     "uv": [
@@ -936,7 +971,27 @@
                         6,
                         4
                     ],
-                    "texture": "#texture"
+                    "texture": "#texture",
+                    "jmx_layers": [
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        },
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        },
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        }
+                    ]
                 },
                 "south": {
                     "uv": [
@@ -945,7 +1000,27 @@
                         6,
                         4
                     ],
-                    "texture": "#texture"
+                    "texture": "#texture",
+                    "jmx_layers": [
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        },
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        },
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        }
+                    ]
                 }
             }
         },
@@ -969,7 +1044,27 @@
                         14,
                         9
                     ],
-                    "texture": "#texture"
+                    "texture": "#texture",
+                    "jmx_layers": [
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        },
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        },
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        }
+                    ]
                 },
                 "up": {
                     "uv": [
@@ -978,7 +1073,27 @@
                         14,
                         9
                     ],
-                    "texture": "#texture"
+                    "texture": "#texture",
+                    "jmx_layers": [
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        },
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        },
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        }
+                    ]
                 },
                 "north": {
                     "uv": [
@@ -987,7 +1102,27 @@
                         14,
                         10
                     ],
-                    "texture": "#texture"
+                    "texture": "#texture",
+                    "jmx_layers": [
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        },
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        },
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        }
+                    ]
                 },
                 "south": {
                     "uv": [
@@ -996,7 +1131,27 @@
                         14,
                         10
                     ],
-                    "texture": "#texture"
+                    "texture": "#texture",
+                    "jmx_layers": [
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        },
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        },
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        }
+                    ]
                 }
             }
         },
@@ -1020,7 +1175,27 @@
                         14,
                         9
                     ],
-                    "texture": "#texture"
+                    "texture": "#texture",
+                    "jmx_layers": [
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        },
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        },
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        }
+                    ]
                 },
                 "up": {
                     "uv": [
@@ -1029,7 +1204,27 @@
                         14,
                         9
                     ],
-                    "texture": "#texture"
+                    "texture": "#texture",
+                    "jmx_layers": [
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        },
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        },
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        }
+                    ]
                 },
                 "north": {
                     "uv": [
@@ -1038,7 +1233,27 @@
                         14,
                         4
                     ],
-                    "texture": "#texture"
+                    "texture": "#texture",
+                    "jmx_layers": [
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        },
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        },
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        }
+                    ]
                 },
                 "south": {
                     "uv": [
@@ -1047,10 +1262,35 @@
                         14,
                         4
                     ],
-                    "texture": "#texture"
+                    "texture": "#texture",
+                    "jmx_layers": [
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        },
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        },
+                        {
+                            "texture": "#jmx_texture",
+                            "material": "#jmx_material",
+                            "tag": "#jmx_tag",
+                            "color": "#jmx_color"
+                        }
+                    ]
                 }
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/3/jmx_template_fence_gate_wall_open.json
+++ b/src/main/resources/assets/jmx/models/block/v1/3/jmx_template_fence_gate_wall_open.json
@@ -3,11 +3,6 @@
     "textures": {
         "particle": "#texture"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "__comment": "Left-hand post",
@@ -1292,5 +1287,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/3/jmx_template_glass_pane_noside.json
+++ b/src/main/resources/assets/jmx/models/block/v1/3/jmx_template_glass_pane_noside.json
@@ -3,11 +3,6 @@
     "textures": {
         "particle": "#pane"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -53,5 +48,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/3/jmx_template_glass_pane_noside_alt.json
+++ b/src/main/resources/assets/jmx/models/block/v1/3/jmx_template_glass_pane_noside_alt.json
@@ -3,11 +3,6 @@
     "textures": {
         "particle": "#pane"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -53,5 +48,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/3/jmx_template_glass_pane_post.json
+++ b/src/main/resources/assets/jmx/models/block/v1/3/jmx_template_glass_pane_post.json
@@ -3,11 +3,6 @@
     "textures": {
         "particle": "#pane"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -82,5 +77,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/3/jmx_template_glass_pane_side.json
+++ b/src/main/resources/assets/jmx/models/block/v1/3/jmx_template_glass_pane_side.json
@@ -3,11 +3,6 @@
     "textures": {
         "particle": "#pane"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -170,5 +165,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/3/jmx_template_glass_pane_side_alt.json
+++ b/src/main/resources/assets/jmx/models/block/v1/3/jmx_template_glass_pane_side_alt.json
@@ -3,11 +3,6 @@
     "textures": {
         "particle": "#pane"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -170,5 +165,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/3/jmx_template_glazed_terracotta.json
+++ b/src/main/resources/assets/jmx/models/block/v1/3/jmx_template_glazed_terracotta.json
@@ -1,5 +1,8 @@
 {
     "parent": "jmx:block/v1/3/jmx_cube",
+    "textures": {
+        "particle": "#pattern"
+    },
     "display": {
         "firstperson_righthand": {
             "rotation": [
@@ -219,5 +222,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/3/jmx_template_orientable_trapdoor_bottom.json
+++ b/src/main/resources/assets/jmx/models/block/v1/3/jmx_template_orientable_trapdoor_bottom.json
@@ -3,11 +3,6 @@
     "textures": {
         "particle": "#texture"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -203,5 +198,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/3/jmx_template_orientable_trapdoor_open.json
+++ b/src/main/resources/assets/jmx/models/block/v1/3/jmx_template_orientable_trapdoor_open.json
@@ -2,11 +2,6 @@
     "textures": {
         "particle": "#texture"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -204,5 +199,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/3/jmx_template_orientable_trapdoor_top.json
+++ b/src/main/resources/assets/jmx/models/block/v1/3/jmx_template_orientable_trapdoor_top.json
@@ -2,11 +2,6 @@
     "textures": {
         "particle": "#texture"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -202,5 +197,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/3/jmx_template_piston.json
+++ b/src/main/resources/assets/jmx/models/block/v1/3/jmx_template_piston.json
@@ -2,11 +2,6 @@
     "textures": {
         "particle": "#side"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -206,5 +201,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/3/jmx_template_piston_head.json
+++ b/src/main/resources/assets/jmx/models/block/v1/3/jmx_template_piston_head.json
@@ -2,11 +2,6 @@
     "textures": {
         "particle": "#platform"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -337,5 +332,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/3/jmx_template_piston_head_short.json
+++ b/src/main/resources/assets/jmx/models/block/v1/3/jmx_template_piston_head_short.json
@@ -2,11 +2,6 @@
     "textures": {
         "particle": "#platform"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -337,5 +332,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/3/jmx_template_rail_raised_ne.json
+++ b/src/main/resources/assets/jmx/models/block/v1/3/jmx_template_rail_raised_ne.json
@@ -3,11 +3,6 @@
     "textures": {
         "particle": "#rail"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -92,5 +87,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/3/jmx_template_rail_raised_sw.json
+++ b/src/main/resources/assets/jmx/models/block/v1/3/jmx_template_rail_raised_sw.json
@@ -3,11 +3,6 @@
     "textures": {
         "particle": "#rail"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -92,5 +87,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/3/jmx_template_torch.json
+++ b/src/main/resources/assets/jmx/models/block/v1/3/jmx_template_torch.json
@@ -3,11 +3,6 @@
     "textures": {
         "particle": "#torch"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -229,5 +224,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/3/jmx_template_trapdoor_bottom.json
+++ b/src/main/resources/assets/jmx/models/block/v1/3/jmx_template_trapdoor_bottom.json
@@ -3,11 +3,6 @@
     "textures": {
         "particle": "#texture"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -203,5 +198,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/3/jmx_template_trapdoor_open.json
+++ b/src/main/resources/assets/jmx/models/block/v1/3/jmx_template_trapdoor_open.json
@@ -2,11 +2,6 @@
     "textures": {
         "particle": "#texture"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -202,5 +197,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/3/jmx_template_trapdoor_top.json
+++ b/src/main/resources/assets/jmx/models/block/v1/3/jmx_template_trapdoor_top.json
@@ -2,11 +2,6 @@
     "textures": {
         "particle": "#texture"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -202,5 +197,10 @@
             }
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/3/jmx_template_wall_side.json
+++ b/src/main/resources/assets/jmx/models/block/v1/3/jmx_template_wall_side.json
@@ -2,11 +2,6 @@
     "textures": {
         "particle": "#wall"
     },
-    "jmx": {
-        "textures": {
-            "particle": "#jmx_tex_particle"
-        }
-    },
     "elements": [
         {
             "from": [
@@ -141,5 +136,10 @@
             "__comment": "wall"
         }
     ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
     "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/3/jmx_template_wall_side_tall.json
+++ b/src/main/resources/assets/jmx/models/block/v1/3/jmx_template_wall_side_tall.json
@@ -11,7 +11,7 @@
             ],
             "to": [
                 11,
-                14,
+                16,
                 8
             ],
             "faces": {
@@ -30,12 +30,25 @@
                             "material": "#jmx_mat_wall",
                             "tag": "#jmx_tag_wall",
                             "color": "#jmx_color_wall"
+                        },
+                        {
+                            "texture": "#jmx_tex_wall",
+                            "material": "#jmx_mat_wall",
+                            "tag": "#jmx_tag_wall",
+                            "color": "#jmx_color_wall"
                         }
                     ]
                 },
                 "up": {
                     "texture": "#wall",
+                    "cullface": "up",
                     "jmx_layers": [
+                        {
+                            "texture": "#jmx_tex_wall",
+                            "material": "#jmx_mat_wall",
+                            "tag": "#jmx_tag_wall",
+                            "color": "#jmx_color_wall"
+                        },
                         {
                             "texture": "#jmx_tex_wall",
                             "material": "#jmx_mat_wall",
@@ -65,12 +78,24 @@
                             "material": "#jmx_mat_wall",
                             "tag": "#jmx_tag_wall",
                             "color": "#jmx_color_wall"
+                        },
+                        {
+                            "texture": "#jmx_tex_wall",
+                            "material": "#jmx_mat_wall",
+                            "tag": "#jmx_tag_wall",
+                            "color": "#jmx_color_wall"
                         }
                     ]
                 },
                 "west": {
                     "texture": "#wall",
                     "jmx_layers": [
+                        {
+                            "texture": "#jmx_tex_wall",
+                            "material": "#jmx_mat_wall",
+                            "tag": "#jmx_tag_wall",
+                            "color": "#jmx_color_wall"
+                        },
                         {
                             "texture": "#jmx_tex_wall",
                             "material": "#jmx_mat_wall",
@@ -99,11 +124,16 @@
                             "material": "#jmx_mat_wall",
                             "tag": "#jmx_tag_wall",
                             "color": "#jmx_color_wall"
+                        },
+                        {
+                            "texture": "#jmx_tex_wall",
+                            "material": "#jmx_mat_wall",
+                            "tag": "#jmx_tag_wall",
+                            "color": "#jmx_color_wall"
                         }
                     ]
                 }
-            },
-            "__comment": "wall"
+            }
         }
     ],
     "jmx": {

--- a/src/main/resources/assets/jmx/models/block/v1/3/jmx_wall_inventory.json
+++ b/src/main/resources/assets/jmx/models/block/v1/3/jmx_wall_inventory.json
@@ -1,0 +1,433 @@
+{
+    "parent": "jmx:block/v1/block",
+    "display": {
+        "gui": {
+            "rotation": [
+                30,
+                135,
+                0
+            ],
+            "translation": [
+                0,
+                0,
+                0
+            ],
+            "scale": [
+                0.625,
+                0.625,
+                0.625
+            ]
+        },
+        "fixed": {
+            "rotation": [
+                0,
+                90,
+                0
+            ],
+            "translation": [
+                0,
+                0,
+                0
+            ],
+            "scale": [
+                0.5,
+                0.5,
+                0.5
+            ]
+        }
+    },
+    "ambientocclusion": false,
+    "textures": {
+        "particle": "#wall"
+    },
+    "elements": [
+        {
+            "from": [
+                4,
+                0,
+                4
+            ],
+            "to": [
+                12,
+                16,
+                12
+            ],
+            "faces": {
+                "down": {
+                    "uv": [
+                        4,
+                        4,
+                        12,
+                        12
+                    ],
+                    "texture": "#wall",
+                    "cullface": "down",
+                    "jmx_layers": [
+                        {
+                            "texture": "#jmx_tex_wall",
+                            "material": "#jmx_mat_wall",
+                            "tag": "#jmx_tag_wall",
+                            "color": "#jmx_color_wall"
+                        },
+                        {
+                            "texture": "#jmx_tex_wall",
+                            "material": "#jmx_mat_wall",
+                            "tag": "#jmx_tag_wall",
+                            "color": "#jmx_color_wall"
+                        },
+                        {
+                            "texture": "#jmx_tex_wall",
+                            "material": "#jmx_mat_wall",
+                            "tag": "#jmx_tag_wall",
+                            "color": "#jmx_color_wall"
+                        }
+                    ]
+                },
+                "up": {
+                    "uv": [
+                        4,
+                        4,
+                        12,
+                        12
+                    ],
+                    "texture": "#wall",
+                    "jmx_layers": [
+                        {
+                            "texture": "#jmx_tex_wall",
+                            "material": "#jmx_mat_wall",
+                            "tag": "#jmx_tag_wall",
+                            "color": "#jmx_color_wall"
+                        },
+                        {
+                            "texture": "#jmx_tex_wall",
+                            "material": "#jmx_mat_wall",
+                            "tag": "#jmx_tag_wall",
+                            "color": "#jmx_color_wall"
+                        },
+                        {
+                            "texture": "#jmx_tex_wall",
+                            "material": "#jmx_mat_wall",
+                            "tag": "#jmx_tag_wall",
+                            "color": "#jmx_color_wall"
+                        }
+                    ]
+                },
+                "north": {
+                    "uv": [
+                        4,
+                        0,
+                        12,
+                        16
+                    ],
+                    "texture": "#wall",
+                    "jmx_layers": [
+                        {
+                            "texture": "#jmx_tex_wall",
+                            "material": "#jmx_mat_wall",
+                            "tag": "#jmx_tag_wall",
+                            "color": "#jmx_color_wall"
+                        },
+                        {
+                            "texture": "#jmx_tex_wall",
+                            "material": "#jmx_mat_wall",
+                            "tag": "#jmx_tag_wall",
+                            "color": "#jmx_color_wall"
+                        },
+                        {
+                            "texture": "#jmx_tex_wall",
+                            "material": "#jmx_mat_wall",
+                            "tag": "#jmx_tag_wall",
+                            "color": "#jmx_color_wall"
+                        }
+                    ]
+                },
+                "south": {
+                    "uv": [
+                        4,
+                        0,
+                        12,
+                        16
+                    ],
+                    "texture": "#wall",
+                    "jmx_layers": [
+                        {
+                            "texture": "#jmx_tex_wall",
+                            "material": "#jmx_mat_wall",
+                            "tag": "#jmx_tag_wall",
+                            "color": "#jmx_color_wall"
+                        },
+                        {
+                            "texture": "#jmx_tex_wall",
+                            "material": "#jmx_mat_wall",
+                            "tag": "#jmx_tag_wall",
+                            "color": "#jmx_color_wall"
+                        },
+                        {
+                            "texture": "#jmx_tex_wall",
+                            "material": "#jmx_mat_wall",
+                            "tag": "#jmx_tag_wall",
+                            "color": "#jmx_color_wall"
+                        }
+                    ]
+                },
+                "west": {
+                    "uv": [
+                        4,
+                        0,
+                        12,
+                        16
+                    ],
+                    "texture": "#wall",
+                    "jmx_layers": [
+                        {
+                            "texture": "#jmx_tex_wall",
+                            "material": "#jmx_mat_wall",
+                            "tag": "#jmx_tag_wall",
+                            "color": "#jmx_color_wall"
+                        },
+                        {
+                            "texture": "#jmx_tex_wall",
+                            "material": "#jmx_mat_wall",
+                            "tag": "#jmx_tag_wall",
+                            "color": "#jmx_color_wall"
+                        },
+                        {
+                            "texture": "#jmx_tex_wall",
+                            "material": "#jmx_mat_wall",
+                            "tag": "#jmx_tag_wall",
+                            "color": "#jmx_color_wall"
+                        }
+                    ]
+                },
+                "east": {
+                    "uv": [
+                        4,
+                        0,
+                        12,
+                        16
+                    ],
+                    "texture": "#wall",
+                    "jmx_layers": [
+                        {
+                            "texture": "#jmx_tex_wall",
+                            "material": "#jmx_mat_wall",
+                            "tag": "#jmx_tag_wall",
+                            "color": "#jmx_color_wall"
+                        },
+                        {
+                            "texture": "#jmx_tex_wall",
+                            "material": "#jmx_mat_wall",
+                            "tag": "#jmx_tag_wall",
+                            "color": "#jmx_color_wall"
+                        },
+                        {
+                            "texture": "#jmx_tex_wall",
+                            "material": "#jmx_mat_wall",
+                            "tag": "#jmx_tag_wall",
+                            "color": "#jmx_color_wall"
+                        }
+                    ]
+                }
+            },
+            "__comment": "Center post"
+        },
+        {
+            "from": [
+                5,
+                0,
+                0
+            ],
+            "to": [
+                11,
+                13,
+                16
+            ],
+            "faces": {
+                "down": {
+                    "uv": [
+                        5,
+                        0,
+                        11,
+                        16
+                    ],
+                    "texture": "#wall",
+                    "cullface": "down",
+                    "jmx_layers": [
+                        {
+                            "texture": "#jmx_tex_wall",
+                            "material": "#jmx_mat_wall",
+                            "tag": "#jmx_tag_wall",
+                            "color": "#jmx_color_wall"
+                        },
+                        {
+                            "texture": "#jmx_tex_wall",
+                            "material": "#jmx_mat_wall",
+                            "tag": "#jmx_tag_wall",
+                            "color": "#jmx_color_wall"
+                        },
+                        {
+                            "texture": "#jmx_tex_wall",
+                            "material": "#jmx_mat_wall",
+                            "tag": "#jmx_tag_wall",
+                            "color": "#jmx_color_wall"
+                        }
+                    ]
+                },
+                "up": {
+                    "uv": [
+                        5,
+                        0,
+                        11,
+                        16
+                    ],
+                    "texture": "#wall",
+                    "jmx_layers": [
+                        {
+                            "texture": "#jmx_tex_wall",
+                            "material": "#jmx_mat_wall",
+                            "tag": "#jmx_tag_wall",
+                            "color": "#jmx_color_wall"
+                        },
+                        {
+                            "texture": "#jmx_tex_wall",
+                            "material": "#jmx_mat_wall",
+                            "tag": "#jmx_tag_wall",
+                            "color": "#jmx_color_wall"
+                        },
+                        {
+                            "texture": "#jmx_tex_wall",
+                            "material": "#jmx_mat_wall",
+                            "tag": "#jmx_tag_wall",
+                            "color": "#jmx_color_wall"
+                        }
+                    ]
+                },
+                "north": {
+                    "uv": [
+                        5,
+                        3,
+                        11,
+                        16
+                    ],
+                    "texture": "#wall",
+                    "cullface": "north",
+                    "jmx_layers": [
+                        {
+                            "texture": "#jmx_tex_wall",
+                            "material": "#jmx_mat_wall",
+                            "tag": "#jmx_tag_wall",
+                            "color": "#jmx_color_wall"
+                        },
+                        {
+                            "texture": "#jmx_tex_wall",
+                            "material": "#jmx_mat_wall",
+                            "tag": "#jmx_tag_wall",
+                            "color": "#jmx_color_wall"
+                        },
+                        {
+                            "texture": "#jmx_tex_wall",
+                            "material": "#jmx_mat_wall",
+                            "tag": "#jmx_tag_wall",
+                            "color": "#jmx_color_wall"
+                        }
+                    ]
+                },
+                "south": {
+                    "uv": [
+                        5,
+                        3,
+                        11,
+                        16
+                    ],
+                    "texture": "#wall",
+                    "cullface": "south",
+                    "jmx_layers": [
+                        {
+                            "texture": "#jmx_tex_wall",
+                            "material": "#jmx_mat_wall",
+                            "tag": "#jmx_tag_wall",
+                            "color": "#jmx_color_wall"
+                        },
+                        {
+                            "texture": "#jmx_tex_wall",
+                            "material": "#jmx_mat_wall",
+                            "tag": "#jmx_tag_wall",
+                            "color": "#jmx_color_wall"
+                        },
+                        {
+                            "texture": "#jmx_tex_wall",
+                            "material": "#jmx_mat_wall",
+                            "tag": "#jmx_tag_wall",
+                            "color": "#jmx_color_wall"
+                        }
+                    ]
+                },
+                "west": {
+                    "uv": [
+                        0,
+                        3,
+                        16,
+                        16
+                    ],
+                    "texture": "#wall",
+                    "jmx_layers": [
+                        {
+                            "texture": "#jmx_tex_wall",
+                            "material": "#jmx_mat_wall",
+                            "tag": "#jmx_tag_wall",
+                            "color": "#jmx_color_wall"
+                        },
+                        {
+                            "texture": "#jmx_tex_wall",
+                            "material": "#jmx_mat_wall",
+                            "tag": "#jmx_tag_wall",
+                            "color": "#jmx_color_wall"
+                        },
+                        {
+                            "texture": "#jmx_tex_wall",
+                            "material": "#jmx_mat_wall",
+                            "tag": "#jmx_tag_wall",
+                            "color": "#jmx_color_wall"
+                        }
+                    ]
+                },
+                "east": {
+                    "uv": [
+                        0,
+                        3,
+                        16,
+                        16
+                    ],
+                    "texture": "#wall",
+                    "jmx_layers": [
+                        {
+                            "texture": "#jmx_tex_wall",
+                            "material": "#jmx_mat_wall",
+                            "tag": "#jmx_tag_wall",
+                            "color": "#jmx_color_wall"
+                        },
+                        {
+                            "texture": "#jmx_tex_wall",
+                            "material": "#jmx_mat_wall",
+                            "tag": "#jmx_tag_wall",
+                            "color": "#jmx_color_wall"
+                        },
+                        {
+                            "texture": "#jmx_tex_wall",
+                            "material": "#jmx_mat_wall",
+                            "tag": "#jmx_tag_wall",
+                            "color": "#jmx_color_wall"
+                        }
+                    ]
+                }
+            },
+            "__comment": "Full wall"
+        }
+    ],
+    "jmx": {
+        "textures": {
+            "particle": "#jmx_tex_particle"
+        }
+    },
+    "jmx_version": 1
+}

--- a/src/main/resources/assets/jmx/models/block/v1/block.json
+++ b/src/main/resources/assets/jmx/models/block/v1/block.json
@@ -1,36 +1,108 @@
 {
-	"gui_light": "side",
-	"display": {
-		"gui": {
-			"rotation": [ 30, 225, 0 ],
-			"translation": [ 0, 0, 0],
-			"scale":[ 0.625, 0.625, 0.625 ]
-		},
-		"ground": {
-			"rotation": [ 0, 0, 0 ],
-			"translation": [ 0, 3, 0],
-			"scale":[ 0.25, 0.25, 0.25 ]
-		},
-		"fixed": {
-			"rotation": [ 0, 0, 0 ],
-			"translation": [ 0, 0, 0],
-			"scale":[ 0.5, 0.5, 0.5 ]
-		},
-		"thirdperson_righthand": {
-			"rotation": [ 75, 45, 0 ],
-			"translation": [ 0, 2.5, 0],
-			"scale": [ 0.375, 0.375, 0.375 ]
-		},
-		"firstperson_righthand": {
-			"rotation": [ 0, 45, 0 ],
-			"translation": [ 0, 0, 0 ],
-			"scale": [ 0.40, 0.40, 0.40 ]
-		},
-		"firstperson_lefthand": {
-			"rotation": [ 0, 225, 0 ],
-			"translation": [ 0, 0, 0 ],
-			"scale": [ 0.40, 0.40, 0.40 ]
-		}
-	},
-	"jmx_version": 1
+    "gui_light": "side",
+    "display": {
+        "gui": {
+            "rotation": [
+                30,
+                225,
+                0
+            ],
+            "translation": [
+                0,
+                0,
+                0
+            ],
+            "scale": [
+                0.625,
+                0.625,
+                0.625
+            ]
+        },
+        "ground": {
+            "rotation": [
+                0,
+                0,
+                0
+            ],
+            "translation": [
+                0,
+                3,
+                0
+            ],
+            "scale": [
+                0.25,
+                0.25,
+                0.25
+            ]
+        },
+        "fixed": {
+            "rotation": [
+                0,
+                0,
+                0
+            ],
+            "translation": [
+                0,
+                0,
+                0
+            ],
+            "scale": [
+                0.5,
+                0.5,
+                0.5
+            ]
+        },
+        "thirdperson_righthand": {
+            "rotation": [
+                75,
+                45,
+                0
+            ],
+            "translation": [
+                0,
+                2.5,
+                0
+            ],
+            "scale": [
+                0.375,
+                0.375,
+                0.375
+            ]
+        },
+        "firstperson_righthand": {
+            "rotation": [
+                0,
+                45,
+                0
+            ],
+            "translation": [
+                0,
+                0,
+                0
+            ],
+            "scale": [
+                0.4,
+                0.4,
+                0.4
+            ]
+        },
+        "firstperson_lefthand": {
+            "rotation": [
+                0,
+                225,
+                0
+            ],
+            "translation": [
+                0,
+                0,
+                0
+            ],
+            "scale": [
+                0.4,
+                0.4,
+                0.4
+            ]
+        }
+    },
+    "jmx_version": 1
 }

--- a/src/main/resources/assets/jmx/models/block/v1/thin_block.json
+++ b/src/main/resources/assets/jmx/models/block/v1/thin_block.json
@@ -1,20 +1,57 @@
-{   "parent": "jmx:block/v1/block",
-	"display": {
-		"thirdperson_righthand": {
-			"rotation": [ 75, 45, 0 ],
-			"translation": [ 0, 2.5, 2],
-			"scale": [ 0.375, 0.375, 0.375 ]
-		},
-		"firstperson_righthand": {
-			"rotation": [ 0, 45, 0 ],
-			"translation": [ 0, 4.2, 0 ],
-			"scale": [ 0.40, 0.40, 0.40 ]
-		},
-		"firstperson_lefthand": {
-			"rotation": [ 0, 225, 0 ],
-			"translation": [ 0, 4.2, 0 ],
-			"scale": [ 0.40, 0.40, 0.40 ]
-		}
-	},
-	"jmx_version": 1
+{
+    "parent": "jmx:block/v1/block",
+    "display": {
+        "thirdperson_righthand": {
+            "rotation": [
+                75,
+                45,
+                0
+            ],
+            "translation": [
+                0,
+                2.5,
+                2
+            ],
+            "scale": [
+                0.375,
+                0.375,
+                0.375
+            ]
+        },
+        "firstperson_righthand": {
+            "rotation": [
+                0,
+                45,
+                0
+            ],
+            "translation": [
+                0,
+                4.2,
+                0
+            ],
+            "scale": [
+                0.4,
+                0.4,
+                0.4
+            ]
+        },
+        "firstperson_lefthand": {
+            "rotation": [
+                0,
+                225,
+                0
+            ],
+            "translation": [
+                0,
+                4.2,
+                0
+            ],
+            "scale": [
+                0.4,
+                0.4,
+                0.4
+            ]
+        }
+    },
+    "jmx_version": 1
 }


### PR DESCRIPTION
See [the script](https://github.com/alex5nader/json-model-extensions/blob/9d590888a1396afcd4bee52d7a6539ed448a4170/scripts/make_parent_models_v1.ts#L401-L407) for usage info.

Added `jmx.textures.particle` to all models.

Added the following models:
- template_wall_side_tall
- wall_inventory
- carpet