### PR TITLE
Fix some infinite recursion issues

### DIFF
--- a/fabric/src/main/java/io/vram/jmx/json/JmxModelExt.java
+++ b/fabric/src/main/java/io/vram/jmx/json/JmxModelExt.java
@@ -24,6 +24,9 @@ import java.util.function.Function;
 
 import com.google.gson.JsonObject;
 
+import io.vram.jmx.json.model.BakedQuadFactoryExt;
+import io.vram.jmx.json.v0.JmxModelExtV0;
+import io.vram.jmx.json.v1.JmxModelExtV1;
 import net.minecraft.client.renderer.block.model.BlockModel;
 import net.minecraft.client.renderer.block.model.FaceBakery;
 import net.minecraft.client.renderer.block.model.ItemOverrides;
@@ -33,10 +36,6 @@ import net.minecraft.client.resources.model.Material;
 import net.minecraft.client.resources.model.ModelState;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.GsonHelper;
-
-import io.vram.jmx.json.model.BakedQuadFactoryExt;
-import io.vram.jmx.json.v0.JmxModelExtV0;
-import io.vram.jmx.json.v1.JmxModelExtV1;
 
 public abstract class JmxModelExt<Self extends JmxModelExt<Self>> {
 	public static final ThreadLocal<JmxModelExt<?>> TRANSFER = new ThreadLocal<>();
@@ -69,7 +68,7 @@ public abstract class JmxModelExt<Self extends JmxModelExt<Self>> {
 	 * If a ModelExt is empty, its associated model will be formed by vanilla.
 	 */
 	public boolean hierarchyIsEmpty() {
-		return selfIsEmpty() && (parent == null || parent.hierarchyIsEmpty());
+		return selfIsEmpty() && (parent == null || parent == this || parent.hierarchyIsEmpty());
 	}
 
 	/**

--- a/fabric/src/main/java/io/vram/jmx/json/v0/JmxModelExtV0.java
+++ b/fabric/src/main/java/io/vram/jmx/json/v0/JmxModelExtV0.java
@@ -25,11 +25,20 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.function.Function;
 
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import org.jetbrains.annotations.Nullable;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import io.vram.frex.api.buffer.QuadEmitter;
+import io.vram.frex.api.material.MaterialFinder;
+import io.vram.frex.api.material.RenderMaterial;
+import io.vram.frex.api.renderer.Renderer;
+import io.vram.jmx.JsonModelExtensions;
+import io.vram.jmx.json.JmxModelExt;
+import io.vram.jmx.json.ext.JmxExtension;
+import io.vram.jmx.json.model.JmxBakedModel;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import net.minecraft.client.renderer.block.model.BlockElement;
 import net.minecraft.client.renderer.block.model.BlockElementFace;
 import net.minecraft.client.renderer.block.model.BlockFaceUV;
@@ -43,15 +52,6 @@ import net.minecraft.client.resources.model.ModelState;
 import net.minecraft.core.Direction;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.GsonHelper;
-
-import io.vram.frex.api.buffer.QuadEmitter;
-import io.vram.frex.api.material.MaterialFinder;
-import io.vram.frex.api.material.RenderMaterial;
-import io.vram.frex.api.renderer.Renderer;
-import io.vram.jmx.JsonModelExtensions;
-import io.vram.jmx.json.JmxModelExt;
-import io.vram.jmx.json.ext.JmxExtension;
-import io.vram.jmx.json.model.JmxBakedModel;
 
 public class JmxModelExtV0 extends JmxModelExt<JmxModelExtV0> {
 	private final Map<String, Object> materialMap;
@@ -85,7 +85,7 @@ public class JmxModelExtV0 extends JmxModelExt<JmxModelExtV0> {
 
 	@Nullable
 	private ResourceLocation getQuadTransformId() {
-		return quadTransformId == null && parent != null ? parent.getQuadTransformId() : quadTransformId;
+		return quadTransformId == null && parent != null && parent != this ? parent.getQuadTransformId() : quadTransformId;
 	}
 
 	public JmxMaterialV0 resolveMaterial(String matName) {


### PR DESCRIPTION
AOF6 seems to cause jmx to perform infinite recursion, until a stack overflow error is thrown. This pr adds a check if the parent is the current class to prevent this issue.  
I don't know why the issue was caused in the first place, nor if there are any other spots that I missed. I just know that this prevents the issues. The change is minimally invasive, do with this what you will.